### PR TITLE
Reuse calculated background color and do not double-buffer when using SkijaGC

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
@@ -457,7 +457,7 @@ public class Button extends Control implements ICustomWidget {
 		}
 
 		if (SWT.USE_SKIJA) {
-			gc = new SkijaGC((GC) gc);
+			gc = new SkijaGC((GC) gc, background);
 		}
 
 		boolean isRightAligned = (style & SWT.RIGHT) != 0;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
@@ -432,20 +432,22 @@ public class Button extends Control implements ICustomWidget {
 		IGraphicsContext gc = originalGC;
 		Image doubleBufferingImage = null;
 
-		// Use double buffering on windows
 		if (SWT.getPlatform().equals("win32")) {
 			// Extract background color on first execution
 			if (background == null) {
-				Image backgroundColorImage = new Image(getDisplay(), r.width,
-						r.height);
+				Image backgroundColorImage = new Image(getDisplay(), r.width, r.height);
 				originalGC.copyArea(backgroundColorImage, 0, 0);
 				int pixel = backgroundColorImage.getImageData().getPixel(0, 0);
 				backgroundColorImage.dispose();
-				background = new Color((pixel & 0xFF000000) >>> 24,
-						(pixel & 0xFF0000) >>> 16, (pixel & 0xFF00) >>> 8);
+				background = new Color((pixel & 0xFF000000) >>> 24, (pixel & 0xFF0000) >>> 16, (pixel & 0xFF00) >>> 8);
 			}
 			style |= SWT.NO_BACKGROUND;
+		}
 
+		if (SWT.USE_SKIJA) {
+			gc = new SkijaGC(originalGC, background);
+		} else {
+			// Use double buffering on windows
 			doubleBufferingImage = new Image(getDisplay(), r.width, r.height);
 			originalGC.copyArea(doubleBufferingImage, 0, 0);
 			GC doubleBufferingGC = new GC(doubleBufferingImage);
@@ -454,10 +456,6 @@ public class Button extends Control implements ICustomWidget {
 			doubleBufferingGC.setAntialias(SWT.ON);
 			doubleBufferingGC.fillRectangle(0, 0, r.width, r.height);
 			gc = doubleBufferingGC;
-		}
-
-		if (SWT.USE_SKIJA) {
-			gc = new SkijaGC((GC) gc, background);
 		}
 
 		boolean isRightAligned = (style & SWT.RIGHT) != 0;

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/ControlExample.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/controlexample/ControlExample.java
@@ -105,7 +105,7 @@ public class ControlExample {
 		skijaToggle.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(org.eclipse.swt.events.SelectionEvent e) {
-//				SWT.USE_SKIJA = skijaToggle.getSelection();
+				SWT.USE_SKIJA = skijaToggle.getSelection();
 				parent.layout();
 				parent.redraw(0, 0, parent.getBounds().width, parent.getBounds().height, true);
 			}


### PR DESCRIPTION
- Pass background color to SkijaGC if already calculated
- Only use double-buffering on Windows when not using SkijaGC
- Reenable toggling of SkijaGC in ControlExample