### PR TITLE
Avoid unnecessary background color extraction in SkijaGC

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
@@ -765,7 +765,7 @@ public class Button extends Control implements ICustomWidget {
 		if (text != null && !text.isEmpty()) {
 			GC originalGC = new GC(this);
 			IGraphicsContext gc = SWT.USE_SKIJA
-					? new SkijaGC(originalGC)
+					? new SkijaGC(originalGC, null)
 					: originalGC;
 			gc.setFont(getFont());
 			Point textExtent = gc.textExtent(text, DRAW_FLAGS);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
@@ -193,7 +193,7 @@ public class Label extends Control implements ICustomWidget {
 
 		if (text != null && !"".equals(text)) {
 			GC originalGC = new GC(this);
-			IGraphicsContext gc = SWT.USE_SKIJA ? new SkijaGC(originalGC) : originalGC;
+			IGraphicsContext gc = SWT.USE_SKIJA ? new SkijaGC(originalGC, null) : originalGC;
 			gc.setFont(getFont());
 			Point textExtent = gc.textExtent(text, DRAW_FLAGS);
 			gc.dispose();


### PR DESCRIPTION
When the SkijaGC is initialized without an explicit background color, it is tried to be extracted from the original GC. Whenever the SkijaGC is initialized only to compute the size of a control, this color extraction is unnecessary as no paint operations are performed. This change improves that behavior.

This also prevents errors when running on Linux (with #17) via WSL, which currently yields:
```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f97e27101ec, pid=17344, tid=17349
#
# JRE version: OpenJDK Runtime Environment (17.0.13+11) (build 17.0.13+11-Ubuntu-2ubuntu122.04)
# Java VM: OpenJDK 64-Bit Server VM (17.0.13+11-Ubuntu-2ubuntu122.04, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-am># Problematic frame:
# C  [libcairo.so.2+0x381ec]
#
# Core dump will be written. Default location: Core dumps may be processed with "/wsl-capture-crash %t %E %p %s" (or dumping to /home/hklare/dev/eclipse/p>#
# If you would like to submit a bug report, please visit:
#   https://bugs.launchpad.net/ubuntu/+source/openjdk-17
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#

---------------  S U M M A R Y ------------

Command Line: -Djava.library.path=/home/hklare/dev/eclipse/platform-jdt/misc/prototype-skija/binaries/org.eclipse.swt.gtk.linux.x86_64 -Dfile.encoding=UTF>

Host: Intel(R) Xeon(R) W-11955M CPU @ 2.60GHz, 16 cores, 62G, Ubuntu 22.04.5 LTS
Time: Sat Jan  4 11:18:02 2025 CET elapsed time: 0.862591 seconds (0d 0h 0m 0s)

---------------  T H R E A D  ---------------

Current thread (0x00007f982c018b90):  JavaThread "main" [_thread_in_native, id=17349, stack(0x00007f9833e0f000,0x00007f9833f0f000)]

Stack: [0x00007f9833e0f000,0x00007f9833f0f000],  sp=0x00007f9833f0b720,  free space=1009k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libcairo.so.2+0x381ec]

Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
J 1347  org.eclipse.swt.internal.cairo.Cairo.cairo_paint(J)V (0 bytes) @ 0x00007f981d16d9e9 [0x00007f981d16d9a0+0x0000000000000049]
j  org.eclipse.swt.graphics.GC.copyAreaInPixels(Lorg/eclipse/swt/graphics/Image;II)V+115
j  org.eclipse.swt.graphics.GC.copyArea(Lorg/eclipse/swt/graphics/Image;II)V+70
j  org.eclipse.swt.graphics.SkijaGC.extractBackgroundColor(Lorg/eclipse/swt/graphics/GC;)Lorg/eclipse/swt/graphics/Color;+49
j  org.eclipse.swt.graphics.SkijaGC.<init>(Lorg/eclipse/swt/graphics/GC;)V+3
j  org.eclipse.swt.widgets.Button.computeSize(IIZ)Lorg/eclipse/swt/graphics/Point;+195
```