### PR TITLE
Unify pixel color conversion to be correct on Linux

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/SWT.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/SWT.java
@@ -15,6 +15,7 @@
 package org.eclipse.swt;
 
 
+import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.internal.*;
 import org.eclipse.swt.widgets.*;
 
@@ -4836,6 +4837,14 @@ public static void error (int code) {
  */
 public static void error (int code, Throwable throwable) {
 	error (code, throwable, null);
+}
+
+public static Color convertPixelToColor(int pixelValue) {
+	if (SWT.getPlatform().equals("gtk")) {
+		return new Color((pixelValue & 0xFF0000) >>> 16, (pixelValue & 0xFF00) >>> 8, (pixelValue & 0xFF));
+	} else {
+		return new Color((pixelValue & 0xFF000000) >>> 24, (pixelValue & 0xFF0000) >>> 16, (pixelValue & 0xFF00) >>> 8);
+	}
 }
 
 /**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -47,7 +47,7 @@ public class SkijaGC implements IGraphicsContext {
 		Image colorImage = new Image(gc.getDevice(), originalGCArea.width, originalGCArea.height);
 		gc.copyArea(colorImage, 0, 0);
 		int pixel = colorImage.getImageData().getPixel(0, 0);
-		Color originalColor = new Color((pixel & 0xFF000000) >>> 24, (pixel & 0xFF0000) >>> 16, (pixel & 0xFF00) >>> 8);
+		Color originalColor = SWT.convertPixelToColor(pixel);
 		colorImage.dispose();
 		return originalColor;
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
@@ -610,11 +610,7 @@ public class Button extends Control implements ICustomWidget {
 		originalGC.copyArea(backgroundColorImage, 0, 0);
 		int pixel = backgroundColorImage.getImageData().getPixel(0, 0);
 		backgroundColorImage.dispose();
-		if (SWT.getPlatform().equals("win32")) {
-			background = new Color((pixel & 0xFF000000) >>> 24, (pixel & 0xFF0000) >>> 16, (pixel & 0xFF00) >>> 8);
-		} else if (SWT.getPlatform().equals("gtk")) {
-			background = new Color((pixel & 0xFF0000) >>> 16, (pixel & 0xFF00) >>> 8, (pixel & 0xFF));
-		}
+		background = SWT.convertPixelToColor(pixel);
 	}
 
 	private boolean isArrowButton() {


### PR DESCRIPTION
Color conversion of pixel values to Color objects on Linux has been corrected for buttons in #17, but actually all kinds of widgets may be affected due to the same conversion within SkijaGC. This can also be seen in this comment https://github.com/swt-initiative31/prototype-skija/issues/12#issuecomment-2531164392.

This change unifies the color conversion and corrects it on Linux.

### Before
![Screenshot 2025-01-06 134619](https://github.com/user-attachments/assets/bc04f5fd-32ef-4bbc-b428-15de975a8d6c)

### After
![Screenshot 2025-01-06 134426](https://github.com/user-attachments/assets/b21e796b-8fe5-4402-88ad-50b09d049598)
