### PR TITLE
Fix GC#getFontMetrics() return type on Linux

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
@@ -2263,7 +2263,7 @@ public Font getFont() {
  * </ul>
  */
 @Override
-public IFontMetrics getFontMetrics() {
+public FontMetrics getFontMetrics() {
 	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
 	if (data.context == 0) createLayout();
 	checkGC(FONT);


### PR DESCRIPTION
In the Linux GC implementation, the return type of #getFontMetrics() was unnecessarily changed to IFontMetrics. This is unnecessary as the concrete GC actually returns a specific FontMetrics and the interface IGraphicsContext still specifies the more abstract interface return type. On the contrary, users of GC (such as in Eclipse Platform UI) relying on the return type to be the specific FontMetrics became incompatible due to that change. Thus, this reverts the return type change.