### PR TITLE
Remove faulty GTK-specific import in Button

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
@@ -20,7 +20,6 @@ import org.eclipse.swt.*;
 import org.eclipse.swt.accessibility.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
-import org.eclipse.swt.internal.gtk.*;
 
 /**
  * Instances of this class represent a selectable user interface object that


### PR DESCRIPTION
Thank you, @DieterMai! That import was definitely added erroneously.

Reported here: https://github.com/DieterMai/dma-prototype-skija/commit/a05572c01ce0f3fa36b16d892155debfe2286822#r151167190