### PR TITLE
Unify width/height semantics of GC/SkijaGC

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -183,10 +183,8 @@ public class SkijaGC implements IGraphicsContext {
 			int destWidth, int destHeight) {
 		Canvas canvas = surface.getCanvas();
 		canvas.drawImageRect(convertSWTImageToSkijaImage(image),
-				new Rect(DPIUtil.autoScaleUp(srcX), DPIUtil.autoScaleUp(srcY), DPIUtil.autoScaleUp(srcX + srcWidth),
-						DPIUtil.autoScaleUp(srcY + srcHeight)),
-				new Rect(DPIUtil.autoScaleUp(destX), DPIUtil.autoScaleUp(destY), DPIUtil.autoScaleUp(destX + destWidth),
-						DPIUtil.autoScaleUp(destY + destHeight)));
+				createScaledRectangle(srcX, srcY, srcWidth, srcHeight),
+				createScaledRectangle(destX, destY, destWidth, destHeight));
 
 	}
 
@@ -318,7 +316,8 @@ public class SkijaGC implements IGraphicsContext {
 
 	@Override
 	public void drawLine(int x1, int y1, int x2, int y2) {
-		performDrawLine(paint -> surface.getCanvas().drawLine(x1, y1, x2, y2, paint));
+		performDrawLine(paint -> surface.getCanvas().drawLine(DPIUtil.autoScaleUp(x1 + 0.5f),
+				DPIUtil.autoScaleUp(y1 + 0.5f), DPIUtil.autoScaleUp(x2 + 0.5f), DPIUtil.autoScaleUp(y2 + 0.5f), paint));
 	}
 
 	@Override
@@ -390,7 +389,7 @@ public class SkijaGC implements IGraphicsContext {
 	public void drawFocus(int x, int y, int width, int height) {
 		performDrawLine(paint -> {
 			paint.setPathEffect(PathEffect.makeDash(new float[] { 1.5f, 1.5f }, 0.0f));
-			surface.getCanvas().drawRect(createScaledAndOffsetRectangle(x, y, width, height), paint);
+			surface.getCanvas().drawRect(offsetRectangle(createScaledRectangle(x, y, width, height)), paint);
 		});
 	}
 
@@ -417,7 +416,8 @@ public class SkijaGC implements IGraphicsContext {
 	@Override
 	public void drawOval(int x, int y, int width, int height) {
 		performDrawLine(
-				paint -> surface.getCanvas().drawOval(createScaledAndOffsetRectangle(x, y, width, height), paint));
+				paint -> surface.getCanvas().drawOval(offsetRectangle(createScaledRectangle(x, y, width, height)),
+						paint));
 	}
 
 	public void drawPath(Path path) {
@@ -450,7 +450,8 @@ public class SkijaGC implements IGraphicsContext {
 	@Override
 	public void drawRectangle(int x, int y, int width, int height) {
 		performDrawLine(
-				paint -> surface.getCanvas().drawRect(createScaledAndOffsetRectangle(x, y, width, height), paint));
+				paint -> surface.getCanvas()
+						.drawRect(offsetRectangle(createScaledRectangle(x, y, width, height)), paint));
 	}
 
 	@Override
@@ -483,7 +484,7 @@ public class SkijaGC implements IGraphicsContext {
 	@Override
 	public void fillOval(int x, int y, int width, int height) {
 		performDrawFilled(
-				paint -> surface.getCanvas().drawOval(createScaledAndOffsetRectangle(x, y, width, height), paint));
+				paint -> surface.getCanvas().drawOval(createScaledRectangle(x, y, width, height), paint));
 	}
 
 	public void fillPath(Path path) {
@@ -515,7 +516,7 @@ public class SkijaGC implements IGraphicsContext {
 	@Override
 	public void fillRectangle(int x, int y, int width, int height) {
 		performDrawFilled(
-				paint -> surface.getCanvas().drawRect(createScaledAndOffsetRectangle(x, y, width, height), paint));
+				paint -> surface.getCanvas().drawRect(createScaledRectangle(x, y, width, height), paint));
 	}
 
 	@Override
@@ -611,9 +612,14 @@ public class SkijaGC implements IGraphicsContext {
 		innerGC.setAdvanced(enable);
 	}
 
-	private Rect createScaledAndOffsetRectangle(int x, int y, int width, int height) {
-		return new Rect(DPIUtil.autoScaleUp(x + 0.5f), DPIUtil.autoScaleUp(y + 0.5f),
-				DPIUtil.autoScaleUp(x - 0.5f + width), DPIUtil.autoScaleUp(y - 0.5f + height));
+	private Rect offsetRectangle(Rect rect) {
+		return new Rect(rect.getLeft() + DPIUtil.autoScaleUp(0.5f), rect.getTop() + DPIUtil.autoScaleUp(0.5f),
+				rect.getRight() + DPIUtil.autoScaleUp(0.5f), rect.getBottom() + DPIUtil.autoScaleUp(0.5f));
+	}
+
+	private Rect createScaledRectangle(int x, int y, int width, int height) {
+		return new Rect(DPIUtil.autoScaleUp(x), DPIUtil.autoScaleUp(y), DPIUtil.autoScaleUp(x + width),
+				DPIUtil.autoScaleUp(y + height));
 	}
 
 	@Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
@@ -74,7 +74,7 @@ public class Button extends Control implements ICustomWidget {
 	private static final int RIGHT_MARGIN = 2;
 	private static final int TOP_MARGIN = 0;
 	private static final int BOTTOM_MARGIN = 0;
-	private static final int BOX_SIZE = 13;
+	private static final int BOX_SIZE = 12;
 	private static final int SPACING = 4;
 
 	private static final Color HOVER_COLOR = new Color(Display.getDefault(),
@@ -652,8 +652,7 @@ public class Button extends Control implements ICustomWidget {
 		Color fg = gc.getForeground();
 		if (hasFocus())
 			gc.setForeground(SELECTION_COLOR);
-		gc.drawRoundRectangle(x, y, w - getGCCorrectionValue(),
-				h - getGCCorrectionValue(), 6, 6);
+		gc.drawRoundRectangle(x, y, w - 1, h - 1, 6, 6);
 		gc.setForeground(fg);
 	}
 
@@ -662,21 +661,18 @@ public class Button extends Control implements ICustomWidget {
 			gc.setBackground(SELECTION_COLOR);
 			int partialBoxBorder = 2;
 			gc.fillOval(x + partialBoxBorder, y + partialBoxBorder,
-					BOX_SIZE - 2 * partialBoxBorder,
-					BOX_SIZE - 2 * partialBoxBorder);
+					BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1);
 		}
 		if (hasMouseEntered) {
 			gc.setBackground(HOVER_COLOR);
 			int partialBoxBorder = getSelection() ? 4 : 0;
 			gc.fillOval(x + partialBoxBorder, y + partialBoxBorder,
-					BOX_SIZE - 2 * partialBoxBorder,
-					BOX_SIZE - 2 * partialBoxBorder);
+					BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1);
 		}
 		if (!isEnabled()) {
 			gc.setForeground(getDisplay().getSystemColor(SWT.COLOR_GRAY));
 		}
-		gc.drawOval(x, y, BOX_SIZE - getGCCorrectionValue(),
-				BOX_SIZE - getGCCorrectionValue());
+		gc.drawOval(x, y, BOX_SIZE, BOX_SIZE);
 	}
 
 	private void drawCheckbox(IGraphicsContext gc, int x, int y) {
@@ -688,8 +684,7 @@ public class Button extends Control implements ICustomWidget {
 				gc.setBackground(SELECTION_COLOR);
 			int partialBoxBorder = 2;
 			gc.fillRoundRectangle(x + partialBoxBorder, y + partialBoxBorder,
-					BOX_SIZE - 2 * partialBoxBorder,
-					BOX_SIZE - 2 * partialBoxBorder,
+					BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1,
 					BOX_SIZE / 4 - partialBoxBorder / 2,
 					BOX_SIZE / 4 - partialBoxBorder / 2);
 
@@ -698,17 +693,11 @@ public class Button extends Control implements ICustomWidget {
 			gc.setBackground(HOVER_COLOR);
 			int partialBoxBorder = getSelection() ? 4 : 0;
 			gc.fillRoundRectangle(x + partialBoxBorder, y + partialBoxBorder,
-					BOX_SIZE - 2 * partialBoxBorder,
-					BOX_SIZE - 2 * partialBoxBorder,
+					BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1,
 					BOX_SIZE / 4 - partialBoxBorder / 2,
 					BOX_SIZE / 4 - partialBoxBorder / 2);
 		}
-		gc.drawRoundRectangle(x, y, BOX_SIZE - getGCCorrectionValue(),
-				BOX_SIZE - getGCCorrectionValue(), 4, 4);
-	}
-
-	private int getGCCorrectionValue() {
-		return SWT.USE_SKIJA ? 0 : 1;
+		gc.drawRoundRectangle(x, y, BOX_SIZE, BOX_SIZE, 4, 4);
 	}
 
 	@Override


### PR DESCRIPTION
The GC and SkijaGC implementations currently behave inconsistently with respect to the meaning of width and height of rectangles. For that reason, controls like Button contain a correction calculation depending on the used GC.
In addition, filled areas drawn with SkijaGC become blurry, as the offset required for drawing the outline of rectangles or ovals (in order to place lines in the middle of a pixel) must not be applied here.

Since conformance with the existing API (of GC) shall be maintained, this adapts the interpretation of width and height in SkijaGC to the one in GC by the following changes:
- Unify offset application for rectangles and ovals adapting the SkijaGC implementation to the GC one
- Remove faulty offset application from fillRectangle and fillOval methods
- Apply offset for drawing lines in SkijaGC

⚠️ Only tested on Windows so far

### Before
![image](https://github.com/user-attachments/assets/92df6aa5-034b-4e88-8a58-12d36c709b0a)

### After
![image](https://github.com/user-attachments/assets/4b1cb969-9375-4d4b-8e57-4565d51fcc7b)
