### PR TITLE
[Win] Fix isScrolled() check in Control

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -685,7 +685,7 @@ void createHandle () {
 		// else the old drawings stay in the area.
 		state |= CANVAS;
 
-		if (isScrolled() || findThemeControl() == parent) {
+		if (!isScrolled() || findThemeControl() == parent) {
 			state |= THEME_BACKGROUND;
 		}
 		if ((style & SWT.TRANSPARENT) != 0) {


### PR DESCRIPTION
Fixes an accidentally inverted check for `isScrolled()` in Control on Windows.

Fixes regression introduced by https://github.com/swt-initiative31/prototype-skija/pull/25 reported by @tmssngr (https://github.com/swt-initiative31/prototype-skija/pull/25#issuecomment-2600842019).