### PR TITLE
Fix scale background issues

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Scale.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Scale.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -159,6 +159,7 @@ public class Scale extends Control implements ICustomWidget {
 			case SWT.MouseHorizontalWheel -> onMouseHorizontalWheel(event);
 			case SWT.MouseVerticalWheel -> onMouseVerticalWheel(event);
 			case SWT.Paint -> onPaint(event);
+			case SWT.Resize -> redraw();
 			}
 		};
 		addListener(SWT.KeyDown, listener);
@@ -168,6 +169,7 @@ public class Scale extends Control implements ICustomWidget {
 		addListener(SWT.MouseHorizontalWheel, listener);
 		addListener(SWT.MouseVerticalWheel, listener);
 		addListener(SWT.Paint, listener);
+		addListener(SWT.Resize, listener);
 
 		alignment = style & (SWT.HORIZONTAL | SWT.VERTICAL);
 		orientation = style & (SWT.LEFT_TO_RIGHT | SWT.RIGHT_TO_LEFT);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ScaleRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ScaleRenderer.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.swt.widgets;
 
 import org.eclipse.swt.*;
@@ -32,7 +45,7 @@ class ScaleRenderer implements IScaleRenderer {
 
 		IGraphicsContext sgc = initSkijaGc(nativeGc, bounds);
 
-		renderScale(sgc, 0, 0, bounds.width - 1, bounds.height - 1);
+		renderScale(sgc, 0, 0, bounds.width, bounds.height);
 
 		sgc.commit();
 		sgc.dispose();
@@ -80,7 +93,7 @@ class ScaleRenderer implements IScaleRenderer {
 		// draw background
 		if (background != null) {
 			gc.setBackground(background);
-			gc.fillRectangle(max, y, w - 1, h - 1);
+			gc.fillRectangle(x, y, w, h);
 		}
 
 		int firstNotch;


### PR DESCRIPTION
- When filling background use x for x instead of max
- When filling background don't subtract -1 for width and height
- When rendering scale, use bounds width/height
- React on scale resize event with repainting scale

This changes fix background color issues.
The repainting on resize also fixes a crash that happend when scale was filled horizontally while parent had a background image