### PR TITLE
IGraphicsContext: remove commit method

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/IGraphicsContext.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/IGraphicsContext.java
@@ -1,7 +1,6 @@
 package org.eclipse.swt.graphics;
 
 public interface IGraphicsContext {
-	default void commit() {};
     void dispose();
     void drawLine(int x1, int y1, int x2, int y2);
     void drawRectangle(int x, int y, int width, int height);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -138,7 +138,6 @@ public class SkijaGC implements IGraphicsContext {
 		return lines;
 	}
 
-	@Override
 	public void commit() {
 		io.github.humbleui.skija.Image im = surface.makeImageSnapshot();
 		byte[] imageBytes = EncoderPNG.encode(im).getBytes();

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
@@ -562,7 +562,9 @@ public class Button extends Control implements ICustomWidget {
 			gc.setBackground(bg2);
 		}
 
-		gc.commit();
+		if (gc instanceof SkijaGC sgc) {
+			sgc.commit();
+		}
 		gc.dispose();
 		if (doubleBufferingImage != null) {
 			originalGC.drawImage(doubleBufferingImage, 0, 0);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
@@ -741,7 +741,9 @@ public class Label extends Control implements ICustomWidget {
 			}
 		}
 
-		gc.commit();
+		if (gc instanceof SkijaGC sgc) {
+			sgc.commit();
+		}
 	}
 
 	@Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ScaleRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ScaleRenderer.java
@@ -30,7 +30,7 @@ class ScaleRenderer implements IScaleRenderer {
 	public void render(GC nativeGc, Rectangle bounds) {
 		initBackground(nativeGc, bounds);
 
-		IGraphicsContext sgc = initSkijaGc(nativeGc, bounds);
+		SkijaGC sgc = initSkijaGc(nativeGc, bounds);
 
 		renderScale(sgc, 0, 0, bounds.width - 1, bounds.height - 1);
 
@@ -56,8 +56,8 @@ class ScaleRenderer implements IScaleRenderer {
 		background = SWT.convertPixelToColor(pixel);
 	}
 
-	public IGraphicsContext initSkijaGc(GC originalGC, Rectangle bounds) {
-		IGraphicsContext gc = new SkijaGC(originalGC, background);
+	public SkijaGC initSkijaGc(GC originalGC, Rectangle bounds) {
+		SkijaGC gc = new SkijaGC(originalGC, background);
 
 		originalGC.setClipping(bounds.x, bounds.y, bounds.width, bounds.height);
 


### PR DESCRIPTION
It is an implementation detail which is not needed by the pure drawing code. Instead, SkiaGC.commit should be invoked directly (it is also created in the same methods).