### PR TITLE
SkijaGC: fix fontSize

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -568,7 +568,7 @@ public class SkijaGC implements IGraphicsContext {
 			style = FontStyle.ITALIC;
 		}
 		this.font = new Font(Typeface.makeFromName(fontData.getName(), style));
-		int fontSize = DPIUtil.autoScaleUp(fontData.getHeight());
+		int fontSize = DPIUtil.scaleUp(fontData.getHeight(), DPIUtil.getNativeDeviceZoom());
 		if (SWT.getPlatform().equals("win32")) {
 			fontSize *= this.font.getSize() / innerGC.getDevice().getSystemFont().getFontData()[0].getHeight();
 		}


### PR DESCRIPTION
The windows GC obviously scales the font independent from the SWT autoscaling feature. This change restores this behavior for Skija, too.