### PR TITLE
Pass original (native) GC to GCFactory

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaDrawingAPITest.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaDrawingAPITest.java
@@ -21,32 +21,33 @@ public class SkijaDrawingAPITest {
 
 
 	public static void main (String [] args) {
-
 		Display display = new Display();
 		Shell shell = new Shell(display);
 		shell.setText("SkijaDrawingAPITest");
 		shell.setBounds(10, 10, 1000, 1000);
 
-		shell.setVisible(true);
 		SWT.USE_SKIJA = true;
-		GC skijaGC = GCFactory.createGraphicsContext(shell, SWT.NONE);
-		skijaGC.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
 
-		skijaGC.drawString("yTjJ", 0, 0, false);
-		skijaGC.drawString("yTjJ", 0, 20, true);
-		skijaGC.drawString("yTjJ", 0, 40);
-		for (int i = 20; i < 300; i = i + 4) {
-			skijaGC.drawPoint(100, i);
-		}
-		skijaGC.drawArc(120, 20, 100, 100, 30, 180);
-		skijaGC.fillArc(120, 160, 100, 100, 30, 180);
-		//Test when width and height values are negative
-		skijaGC.fillGradientRectangle(300, 80, -30, -80, false);
-		skijaGC.fillGradientRectangle(300, 80, 30, 80, true);
-		//Test when both foreground and background colors are same
-		skijaGC.setForeground(display.getSystemColor(SWT.COLOR_GREEN));
-		skijaGC.fillGradientRectangle(350, 80, 30, 80, true);
-		skijaGC.commit();
+		shell.addPaintListener(event -> {
+			GC skijaGC = GCFactory.createGraphicsContext(event.gc);
+			skijaGC.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
+
+			skijaGC.drawString("yTjJ", 0, 0, false);
+			skijaGC.drawString("yTjJ", 0, 20, true);
+			skijaGC.drawString("yTjJ", 0, 40);
+			for (int i = 20; i < 300; i = i + 4) {
+				skijaGC.drawPoint(100, i);
+			}
+			skijaGC.drawArc(120, 20, 100, 100, 30, 180);
+			skijaGC.fillArc(120, 160, 100, 100, 30, 180);
+			// Test when width and height values are negative
+			skijaGC.fillGradientRectangle(300, 80, -30, -80, false);
+			skijaGC.fillGradientRectangle(300, 80, 30, 80, true);
+			// Test when both foreground and background colors are same
+			skijaGC.setForeground(display.getSystemColor(SWT.COLOR_GREEN));
+			skijaGC.fillGradientRectangle(350, 80, 30, 80, true);
+			skijaGC.commit();
+		});
 
 		shell.open();
 		while (!shell.isDisposed()) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/GCFactory.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/GCFactory.java
@@ -18,24 +18,30 @@ import org.eclipse.swt.widgets.*;
 
 public class GCFactory {
 
-	public static GC createGraphicsContext(Control c, int style) {
-
-		GCHandle igc = null;
-
+	public static GC createGraphicsContext(Control control) {
+		GCHandle innerGC = null;
 		if (SWT.USE_SKIJA) {
-			igc = new SkijaGC(c, style);
+			innerGC = new SkijaGC(control);
 		} else
-			igc = new NativeGC(c, style);
+			innerGC = new NativeGC(control);
 
 		GC gc = new GC();
-		gc.innerGC = igc;
-
+		gc.innerGC = innerGC;
 		return gc;
-
 	}
 
-	public static GC createGraphicsContext(Control c) {
-		return createGraphicsContext(c, SWT.NONE);
+	public static GC createGraphicsContext(GC originalGC) {
+		if (!SWT.USE_SKIJA) {
+			return originalGC;
+		}
+
+		if (!(originalGC.innerGC instanceof NativeGC originalNativeGC)) {
+			return originalGC;
+		}
+
+		GC gc = new GC();
+		gc.innerGC = new SkijaGC(originalNativeGC, null);
+		return gc;
 	}
 
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
@@ -408,7 +408,7 @@ public class Button extends Control implements ICustomWidget {
 		}
 
 		if (SWT.USE_SKIJA) {
-			gc = GCFactory.createGraphicsContext(this);
+			gc = GCFactory.createGraphicsContext(e.gc);
 		} else {
 			if (SWT.getPlatform().equals("win32")) {
 				// Use double buffering on windows

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
@@ -532,7 +532,7 @@ public class Label extends Control implements ICustomWidget {
 			return;
 		}
 
-		GC gc = GCFactory.createGraphicsContext(this);
+		GC gc = GCFactory.createGraphicsContext(event.gc);
 
 		gc.setFont(font);
 		gc.setBackground(getBackground());


### PR DESCRIPTION
When creating a GC via the GCFactory (e.g., to create a SkijaGC, if enabled), this GC is currently created without considering the original GC that may have already been created, like in the paint event processed by a consumers. Since ignoring the original GC will prevent proper drawing on MacOS, this change proposed to use the original GC by passing it to the GCFactory for now. This is not intended as a final solution but as a temporary one until we have a solution for MacOS.

Contributes to https://github.com/swt-initiative31/prototype-skija/issues/61
See also: 
- https://github.com/swt-initiative31/prototype-skija/pull/62#issue-2833949329