### PR TITLE
Embed Skija libraries in Tycho build

### DIFF
--- a/binaries/org.eclipse.swt.cocoa.macosx.aarch64/build.properties
+++ b/binaries/org.eclipse.swt.cocoa.macosx.aarch64/build.properties
@@ -40,6 +40,9 @@ source.. = \
     ../../bundles/org.eclipse.swt/Eclipse SWT OpenGL/cocoa,\
     ../../bundles/org.eclipse.swt/Eclipse SWT OpenGL/common
 output.. = bin/
+extra..= ../../bundles/org.eclipse.swt/lib/skija-shared-0.116.2.jar,\
+         ../../bundles/org.eclipse.swt/lib/skija-macos-arm64-0.116.2.jar,\
+         ../../bundles/org.eclipse.swt/lib/types-0.1.1.jar
 
 pom.model.property.os=macosx
 pom.model.property.ws=cocoa

--- a/binaries/org.eclipse.swt.gtk.linux.x86_64/build.properties
+++ b/binaries/org.eclipse.swt.gtk.linux.x86_64/build.properties
@@ -43,6 +43,9 @@ source.. = \
 	../../bundles/org.eclipse.swt/Eclipse SWT Tests/common,\
 	../../bundles/org.eclipse.swt/Eclipse SWT WebKit/gtk
 output.. = bin/
+extra..= ../../bundles/org.eclipse.swt/lib/skija-shared-0.116.2.jar,\
+         ../../bundles/org.eclipse.swt/lib/skija-linux-x64-0.116.2.jar,\
+         ../../bundles/org.eclipse.swt/lib/types-0.1.1.jar
 
 pom.model.property.os=linux
 pom.model.property.ws=gtk

--- a/binaries/org.eclipse.swt.win32.win32.x86_64/build.properties
+++ b/binaries/org.eclipse.swt.win32.win32.x86_64/build.properties
@@ -36,6 +36,9 @@ source.. = \
 	../../bundles/org.eclipse.swt/Eclipse SWT OpenGL/win32,\
 	../../bundles/org.eclipse.swt/Eclipse SWT OpenGL/common
 output.. = bin/
+extra..= ../../bundles/org.eclipse.swt/lib/skija-shared-0.116.2.jar,\
+         ../../bundles/org.eclipse.swt/lib/skija-windows-x64-0.116.2.jar,\
+         ../../bundles/org.eclipse.swt/lib/types-0.1.1.jar
 
 pom.model.property.os=win32
 pom.model.property.ws=win32

--- a/binaries/pom.xml
+++ b/binaries/pom.xml
@@ -33,13 +33,13 @@
 	</properties>
 
 	<modules>
-		<module>org.eclipse.swt.cocoa.macosx.x86_64</module>
-		<module>org.eclipse.swt.cocoa.macosx.aarch64</module>
-		<module>org.eclipse.swt.gtk.linux.aarch64</module>
+		<!--<module>org.eclipse.swt.cocoa.macosx.x86_64</module>-->
+		<!--<module>org.eclipse.swt.cocoa.macosx.aarch64</module>-->
+		<!--<module>org.eclipse.swt.gtk.linux.aarch64</module>
 		<module>org.eclipse.swt.gtk.linux.ppc64le</module>
-		<module>org.eclipse.swt.gtk.linux.riscv64</module>
-		<module>org.eclipse.swt.gtk.linux.x86_64</module>
-		<module>org.eclipse.swt.win32.win32.aarch64</module>
+		<module>org.eclipse.swt.gtk.linux.riscv64</module>-->
+		<!--<module>org.eclipse.swt.gtk.linux.x86_64</module>-->
+		<!--<module>org.eclipse.swt.win32.win32.aarch64</module>-->
 		<module>org.eclipse.swt.win32.win32.x86_64</module>
 	</modules>
 


### PR DESCRIPTION
This change adds the Skija libraries to the configuration for the Tycho build of the x64 architecture fragments for Linux and Windows and the ARM architecture fragment for Windows (since we only have added JARs for these architectures so far). It also limits the Tycho build to the Windows fragment for now, as the others face compilation issues. In consequence of this change, the Tycho build without tests will work. The change is limited to executing the build and will not allow to use the generated JARs (as they will not have the Skija JARs embedded so far).

The builds for MacOS and Linux need to be enabled with/after:
- #59
- #62