### PR TITLE
copyArea() API

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaDrawingAPITest.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaDrawingAPITest.java
@@ -46,7 +46,19 @@ public class SkijaDrawingAPITest {
 			// Test when both foreground and background colors are same
 			skijaGC.setForeground(display.getSystemColor(SWT.COLOR_GREEN));
 			skijaGC.fillGradientRectangle(350, 80, 30, 80, true);
+			// Test copyArea
+			Image image = new Image(display, new Rectangle(0, 0, 50, 50));
+			// Copy the area/rectangle present at (100,100,image.width,image.height) into
+			// the image
+			skijaGC.copyArea(image, 100, 100);
+			// Draw the image and check if area/rect is copied to the image
+			skijaGC.drawImage(image, 500, 150);
+			// copy- paste
+			skijaGC.copyArea(300, 80, 20, 50, 400, 50, false);
+
+			skijaGC.copyArea(300, 80, 50, 50, 500, 50, true);
 			skijaGC.commit();
+			image.dispose();
 		});
 
 		shell.open();


### PR DESCRIPTION
APIs implemented in SkijaGC
`copyArea(Image image, int x, int y)` - **partially working**.

I am facing an issue while implementing the `copyArea` API in `SkijaGC`, where I need to convert the copied area/copied Skija image to an SWT Image, but it's resulting in a white rectangle. I have verified that the copied area/Skija image is correct when drawn.

I tried the conversion code from the [commit() method](https://github.com/swt-initiative31/prototype-skija/blob/6ab05f18cde85920bea309e960e914eae2714fdd/bundles/org.eclipse.swt/Eclipse%20SWT/common/org/eclipse/swt/graphics/SkijaGC.java#L195C1-L197C94), but it’s not working.

I also tried creating a Bitmap from the Skija image, reading pixels from the Bitmap, converting the data from RGBA to BGRA, and then creating an SWT Image using the converted pixel data.

`copyArea(int srcX, int srcY, int width, int height, int destX, int destY)` - working.

`copyArea(int srcX, int srcY, int width, int height, int destX, int destY, boolean paint)`  - working
I have a doubt here. I assume it is similar to a cut-paste operation of an area, but my question is whether the original area needs to be cleared or filled with the background color. 
I observe that when drawn on the shell, the Native GC demonstrates the erasing property, while inside a PaintListener, it fills the original area with the background color.