### PR TITLE
Scale: Fix flickering by adapting to new GCHandler implementation

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/GCFactory.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/GCFactory.java
@@ -44,4 +44,20 @@ public class GCFactory {
 		return gc;
 	}
 
+	/**
+	 * Creates a GC using the native GC from the given event or, if not available,
+	 * from the given control.
+	 *
+	 * @param event   The event with the native GC from which to create the GC.
+	 * @param control The control to use as a fallback to create the native GC.
+	 * @return The GC to be used.
+	 */
+	public static GC createGraphicsContext(Event event, Control control) {
+		GC nativeGC = event.gc;
+		if (nativeGC == null) {
+			nativeGC = new GC(control);
+			event.gc = nativeGC;
+		}
+		return createGraphicsContext(nativeGC);
+	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Scale.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Scale.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.swt.widgets;
 
-import java.util.*;
-
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
@@ -43,6 +41,7 @@ import org.eclipse.swt.graphics.*;
  * @noextend This class is not intended to be subclassed by clients.
  */
 public class Scale extends Control implements ICustomWidget {
+	private final static boolean NO_BACKGROUND = SWT.getPlatform().equals("win32") | SWT.getPlatform().equals("gtk");
 	private static final int PREFERRED_WIDTH = 170;
 	private static final int PREFERRED_HEIGHT = 42;
 
@@ -349,21 +348,20 @@ public class Scale extends Control implements ICustomWidget {
 			return;
 		}
 
-		try {
-			event.gc = Objects.requireNonNullElseGet(event.gc, () -> new GC(this));
-			doPaint(event);
-		} finally {
-			event.gc.dispose();
-		}
-	}
-
-	private void doPaint(Event e) {
 		Rectangle bounds = getBounds();
 		if (bounds.width == 0 && bounds.height == 0) {
 			return;
 		}
 
-		renderer.render(e.gc, bounds);
+		if (NO_BACKGROUND) {
+			style |= SWT.NO_BACKGROUND;
+		}
+
+		try {
+			renderer.render(GCFactory.createGraphicsContext(event, this), bounds);
+		} finally {
+			event.gc.dispose();
+		}
 	}
 
 	@Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ScaleRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ScaleRenderer.java
@@ -22,8 +22,6 @@ class ScaleRenderer implements IScaleRenderer {
 	private static final Color HOVER_COLOR = new Color(Display.getDefault(), 0, 0, 0);
 	private static final Color DRAG_COLOR = new Color(Display.getDefault(), 204, 204, 204);
 
-	private static Color background;
-
 	private final Scale scale;
 
 	/**
@@ -40,48 +38,14 @@ class ScaleRenderer implements IScaleRenderer {
 	}
 
 	@Override
-	public void render(GC nativeGc, Rectangle bounds) {
-		initBackground(nativeGc, bounds);
-
-		GC sgc = initSkijaGc(nativeGc, bounds);
-
-		renderScale(sgc, 0, 0, bounds.width, bounds.height);
-
-		sgc.commit();
-		sgc.dispose();
-	}
-
-	private void initBackground(GC originalGC, Rectangle bounds) {
-		if (SWT.getPlatform().equals("win32") | SWT.getPlatform().equals("gtk")) {
-			// Extract background color on first execution
-			if (background == null) {
-				extractAndStoreBackgroundColor(bounds, originalGC);
-			}
-			scale.style |= SWT.NO_BACKGROUND;
+	public void render(GC gc, Rectangle bounds) {
+		try {
+			renderScale(gc, 0, 0, bounds.width, bounds.height);
+		} finally {
+			gc.commit();
+			gc.dispose();
 		}
 	}
-
-	private void extractAndStoreBackgroundColor(Rectangle r, GC originalGC) {
-		Image backgroundColorImage = new Image(scale.getDisplay(), r.width, r.height);
-		originalGC.copyArea(backgroundColorImage, 0, 0);
-		int pixel = backgroundColorImage.getImageData().getPixel(0, 0);
-		backgroundColorImage.dispose();
-		background = SWT.convertPixelToColor(pixel);
-	}
-
-	public GC initSkijaGc(GC originalGC, Rectangle bounds) {
-//		IGraphicsContext gc = new SkijaGC(originalGC, background);
-
-		originalGC.setClipping(bounds.x, bounds.y, bounds.width, bounds.height);
-
-		originalGC.setForeground(scale.getForeground());
-		originalGC.setBackground(scale.getBackground());
-		originalGC.setClipping(new Rectangle(0, 0, bounds.width, bounds.height));
-		originalGC.setAntialias(SWT.ON);
-
-		return originalGC;
-	}
-
 
 	private void renderScale(GC gc, int x, int y, int w, int h) {
 		int value = scale.getSelection();
@@ -89,12 +53,6 @@ class ScaleRenderer implements IScaleRenderer {
 		int max = scale.getMaximum();
 		int units = Math.max(1, max - min);
 		int effectiveValue = Math.min(max, Math.max(min, value));
-
-		// draw background
-		if (background != null) {
-			gc.setBackground(background);
-			gc.fillRectangle(x, y, w, h);
-		}
 
 		int firstNotch;
 		int lastNotch;


### PR DESCRIPTION
The scale widget started flickering after the rework of GC to be a proxy for GCHandler. This changes fixes this by removing much of the GC specific code. This code was for functionality that is handled in GCHandler/SkijaGC/NativeGC anyway.