### PR TITLE
Revert automatic commit in SkijaGC #60

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -16,12 +16,9 @@ package org.eclipse.swt.graphics;
 import java.io.*;
 import java.util.*;
 import java.util.List;
-import java.util.ResourceBundle.*;
 import java.util.function.*;
 
 import org.eclipse.swt.*;
-import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.Resource.*;
 import org.eclipse.swt.internal.*;
 
 import io.github.humbleui.skija.*;
@@ -38,7 +35,6 @@ public class SkijaGC extends GCHandle {
 	private Font font;
 	private float baseSymbolHeight = 0; // Height of symbol with "usual" height, like "T", to be vertically centered
 	private int lineWidth;
-	private boolean committed = false;
 
 	public SkijaGC(org.eclipse.swt.widgets.Control c, int style) {
 
@@ -115,9 +111,6 @@ public class SkijaGC extends GCHandle {
 
 	@Override
 	public void dispose() {
-
-		if (!committed)
-			commit();
 		this.innerGC.dispose();
 	}
 
@@ -188,9 +181,6 @@ public class SkijaGC extends GCHandle {
 
 	@Override
 	public void commit() {
-
-		committed = true;
-
 		io.github.humbleui.skija.Image im = surface.makeImageSnapshot();
 		byte[] imageBytes = EncoderPNG.encode(im).getBytes();
 


### PR DESCRIPTION
The current, automated commit mechanism in SkijaGC is insufficient as it also commits changes in cases where the GC is not used to perform any drawing operations at all. This leads to unintended effects like flickering. This change reverts the automatic commit implementation for now to be replaced by a proper solution later on.

Fixes https://github.com/swt-initiative31/prototype-skija/issues/60

@DenisUngemach wdyt?