### PR TITLE
Light-weight controls managed inside one heavy-weight composite sharing the same GC

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
@@ -55,6 +55,16 @@ import org.eclipse.swt.graphics.*;
  * @noextend This class is not intended to be subclassed by clients.
  */
 public class Button extends Control implements ICustomWidget {
+	public static final String KEY_BUTTON = "button.background"; //$NON-NLS-1$
+	public static final String KEY_HOVER = "button.background.hover"; //$NON-NLS-1$
+	public static final String KEY_TOGGLE = "button.background.toggle"; //$NON-NLS-1$
+	public static final String KEY_SELECTION = "button.background.selection"; //$NON-NLS-1$
+	public static final String KEY_TRISTATE = "button.tristate"; //$NON-NLS-1$
+	public static final String KEY_OUTLINE = "button.outline"; //$NON-NLS-1$
+	public static final String KEY_TEXT = "button.text"; //$NON-NLS-1$
+	public static final String KEY_DISABLE = "button.disable"; //$NON-NLS-1$
+	public static final String KEY_ARROW = "button.arrow"; //$NON-NLS-1$
+
 	String text = "", message = "";
 	Image image, disabledImage;
 	boolean ignoreMouse, grayed, useDarkModeExplorerTheme;
@@ -75,13 +85,6 @@ public class Button extends Control implements ICustomWidget {
 	private static final int BOTTOM_MARGIN = 0;
 	private static final int BOX_SIZE = 12;
 	private static final int SPACING = 4;
-
-	private static final Color HOVER_COLOR = new Color(Display.getDefault(),
-			224, 238, 254);
-	private static final Color TOGGLE_COLOR = new Color(Display.getDefault(),
-			204, 228, 247);
-	private static final Color SELECTION_COLOR = new Color(Display.getDefault(),
-			0, 95, 184); // getDisplay().getSystemColor(SWT.COLOR_WIDGET_DARK_SHADOW)
 
 	private static int DRAW_FLAGS = SWT.DRAW_MNEMONIC | SWT.DRAW_TAB
 			| SWT.DRAW_TRANSPARENT | SWT.DRAW_DELIMITER;
@@ -494,13 +497,14 @@ public class Button extends Control implements ICustomWidget {
 			}
 		}
 
+		final IColorProvider colorProvider = getColorProvider();
+
 		// Draw text
 		if (text != null && !text.isEmpty()) {
 			if (isEnabled()) {
-				gc.setForeground(getDisplay().getSystemColor(SWT.COLOR_BLACK));
+				gc.setForeground(colorProvider.getColor(KEY_TEXT));
 			} else {
-				gc.setForeground(getDisplay()
-						.getSystemColor(SWT.COLOR_WIDGET_NORMAL_SHADOW));
+				gc.setForeground(colorProvider.getColor(KEY_DISABLE));
 			}
 			int textTopOffset = (r.height - 1 - textHeight) / 2;
 			int textLeftOffset = contentArea.x + imageSpace;
@@ -520,8 +524,7 @@ public class Button extends Control implements ICustomWidget {
 		if (isArrowButton()) {
 			Color bg2 = gc.getBackground();
 
-			gc.setBackground(
-					getDisplay().getSystemColor(SWT.COLOR_WIDGET_FOREGROUND));
+			gc.setBackground(colorProvider.getColor(KEY_ARROW));
 
 			int centerHeight = r.height / 2;
 			int centerWidth = r.width / 2;
@@ -591,62 +594,64 @@ public class Button extends Control implements ICustomWidget {
 
 	private void drawPushButton(GC gc, int x, int y, int w,
 			int h) {
+		final IColorProvider colorProvider = getColorProvider();
 		if (isEnabled()) {
 			if ((style & SWT.TOGGLE) != 0 && isChecked()) {
-				gc.setBackground(TOGGLE_COLOR);
+				gc.setBackground(colorProvider.getColor(KEY_TOGGLE));
 			} else if (hasMouseEntered || spaceDown) {
-				gc.setBackground(HOVER_COLOR);
+				gc.setBackground(colorProvider.getColor(KEY_HOVER));
 			} else {
-				gc.setBackground(getDisplay().getSystemColor(SWT.COLOR_WHITE));
+				gc.setBackground(colorProvider.getColor(KEY_BUTTON));
 			}
 			gc.fillRoundRectangle(x, y, w, h, 6, 6);
 		}
 
 		if (isEnabled()) {
 			if ((style & SWT.TOGGLE) != 0 && isChecked() || hasMouseEntered) {
-				gc.setForeground(SELECTION_COLOR);
+				gc.setForeground(colorProvider.getColor(KEY_SELECTION));
 			} else {
-				gc.setForeground(getDisplay()
-						.getSystemColor(SWT.COLOR_WIDGET_NORMAL_SHADOW));
+				gc.setForeground(colorProvider.getColor(KEY_OUTLINE));
 			}
 		} else {
-			gc.setForeground(getDisplay().getSystemColor(SWT.COLOR_GRAY));
+			gc.setForeground(colorProvider.getColor(KEY_DISABLE));
 		}
 
 		// if the button has focus, the border also changes the color
 		Color fg = gc.getForeground();
 		if (hasFocus()) {
-			gc.setForeground(SELECTION_COLOR);
+			gc.setForeground(colorProvider.getColor(KEY_SELECTION));
 		}
 		gc.drawRoundRectangle(x, y, w - 1, h - 1, 6, 6);
 		gc.setForeground(fg);
 	}
 
 	private void drawRadioButton(GC gc, int x, int y) {
+		final IColorProvider colorProvider = getColorProvider();
 		if (getSelection()) {
-			gc.setBackground(SELECTION_COLOR);
+			gc.setBackground(colorProvider.getColor(KEY_SELECTION));
 			int partialBoxBorder = 2;
 			gc.fillOval(x + partialBoxBorder, y + partialBoxBorder,
 					BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1);
 		}
 		if (hasMouseEntered) {
-			gc.setBackground(HOVER_COLOR);
+			gc.setBackground(colorProvider.getColor(KEY_HOVER));
 			int partialBoxBorder = getSelection() ? 4 : 0;
 			gc.fillOval(x + partialBoxBorder, y + partialBoxBorder,
 					BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1);
 		}
 		if (!isEnabled()) {
-			gc.setForeground(getDisplay().getSystemColor(SWT.COLOR_GRAY));
+			gc.setForeground(colorProvider.getColor(KEY_DISABLE));
 		}
 		gc.drawOval(x, y, BOX_SIZE, BOX_SIZE);
 	}
 
 	private void drawCheckbox(GC gc, int x, int y) {
+		final IColorProvider colorProvider = getColorProvider();
 		if (getSelection()) {
 			if (grayed) {
-				gc.setBackground(getDisplay().getSystemColor(SWT.COLOR_GRAY));
+				gc.setBackground(colorProvider.getColor(KEY_TRISTATE));
 			} else {
-				gc.setBackground(SELECTION_COLOR);
+				gc.setBackground(colorProvider.getColor(KEY_SELECTION));
 			}
 			int partialBoxBorder = 2;
 			gc.fillRoundRectangle(x + partialBoxBorder, y + partialBoxBorder,
@@ -656,7 +661,7 @@ public class Button extends Control implements ICustomWidget {
 
 		}
 		if (hasMouseEntered) {
-			gc.setBackground(HOVER_COLOR);
+			gc.setBackground(colorProvider.getColor(KEY_HOVER));
 			int partialBoxBorder = getSelection() ? 4 : 0;
 			gc.fillRoundRectangle(x + partialBoxBorder, y + partialBoxBorder,
 					BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1,

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/IColorProvider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/IColorProvider.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Syntevo GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Thomas Singer (Syntevo) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.graphics.*;
+
+/**
+ * This is an (experimental) class to provide colors for custom-drawn controls.
+ */
+public interface IColorProvider {
+
+	/**
+	 * Returns the color associated with the specified key.
+	 *
+	 * @param key a non-null key
+	 * @return a non-null color
+	 */
+	Color getColor(String key);
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/IMeasureContext.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/IMeasureContext.java
@@ -1,0 +1,10 @@
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.graphics.*;
+
+/**
+ * @author Thomas Singer
+ */
+public interface IMeasureContext {
+	Point textExtent(String text, int drawFlags);
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWAbstractButton.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWAbstractButton.java
@@ -14,42 +14,44 @@ public abstract class LWAbstractButton extends LWControl {
 	protected abstract void handleSelection();
 
 	public static final int EVENT_SELECTED = LWControl.EVENT_NEXT;
-	public static final int EVENT_HOVERED = EVENT_SELECTED + 1;
-	public static final int EVENT_STYLE = EVENT_HOVERED + 1;
-	public static final int EVENT_TEXT = EVENT_STYLE + 1;
+	public static final int EVENT_STYLE = EVENT_SELECTED + 1;
+	public static final int EVENT_HOVERED = EVENT_STYLE + 1;
+	public static final int EVENT_PRESSED = EVENT_HOVERED + 1;
+	public static final int EVENT_TEXT = EVENT_PRESSED + 1;
+	private static final int FLAG_SELECTED = 1;
+	private static final int FLAG_HOVERED = 2;
+	private static final int FLAG_PRESSED = 4;
 
 	protected int style;
 	private String text;
-	private boolean selected;
-	private boolean hovered;
+	private int flags;
 
 	protected LWAbstractButton(int style) {
 		this.style = style;
 	}
 
 	public boolean isSelected() {
-		return selected;
+		return isFlagSet(FLAG_SELECTED);
 	}
 
 	public void setSelected(boolean selected) {
-		if (selected == this.selected) {
-			return;
-		}
-
-		this.selected = selected;
-		notifyListeners(EVENT_SELECTED);
+		setFlag(FLAG_SELECTED, selected, EVENT_SELECTED);
 	}
 
 	public boolean isHovered() {
-		return hovered;
+		return isFlagSet(FLAG_HOVERED);
 	}
 
 	public void setHovered(boolean hovered) {
-		if (hovered == this.hovered) {
-			return;
-		}
-		this.hovered = hovered;
-		notifyListeners(EVENT_HOVERED);
+		setFlag(FLAG_HOVERED, hovered, EVENT_HOVERED);
+	}
+
+	public boolean isPressed() {
+		return isFlagSet(FLAG_PRESSED);
+	}
+
+	public void setPressed(boolean pressed) {
+		setFlag(FLAG_PRESSED, pressed, EVENT_PRESSED);
 	}
 
 	public String getText() {
@@ -67,8 +69,14 @@ public abstract class LWAbstractButton extends LWControl {
 
 	public void handleEvent(Event e) {
 		switch (e.type) {
+		case SWT.MouseDown -> {
+			if (e.button == 1) {
+				setPressed(true);
+			}
+		}
 		case SWT.MouseUp -> {
-			if ((e.stateMask & SWT.BUTTON1) != 0) {
+			if (e.button == 1) {
+				setPressed(false);
 				handleSelection();
 			}
 		}
@@ -84,5 +92,27 @@ public abstract class LWAbstractButton extends LWControl {
 		style |= alignment
 		         & (SWT.UP | SWT.DOWN | SWT.LEFT | SWT.CENTER | SWT.RIGHT);
 		notifyListeners(EVENT_STYLE);
+	}
+
+	private boolean isFlagSet(int mask) {
+		return (flags & mask) == mask;
+	}
+
+	private void setFlag(int mask, boolean set, int eventType) {
+		if (set) {
+			if ((flags & mask) == mask) {
+				return;
+			}
+
+			flags |= mask;
+		}
+		else {
+			if ((flags & mask) == 0) {
+				return;
+			}
+
+			flags &= ~mask;
+		}
+		notifyListeners(eventType);
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWAbstractButton.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWAbstractButton.java
@@ -27,6 +27,12 @@ public abstract class LWAbstractButton extends LWControl {
 	private int flags;
 
 	protected LWAbstractButton(int style) {
+		super(null);
+		this.style = style;
+	}
+
+	protected LWAbstractButton(int style, LWContainer parent) {
+		super(parent);
 		this.style = style;
 	}
 
@@ -67,17 +73,41 @@ public abstract class LWAbstractButton extends LWControl {
 		notifyListeners(EVENT_TEXT);
 	}
 
+	@Override
+	protected void notifyListeners(int type) {
+		super.notifyListeners(type);
+		redraw();
+	}
+
+	@Override
 	public void handleEvent(Event e) {
 		switch (e.type) {
 		case SWT.MouseDown -> {
 			if (e.button == 1) {
 				setPressed(true);
+				redraw();
 			}
 		}
 		case SWT.MouseUp -> {
 			if (e.button == 1) {
 				setPressed(false);
 				handleSelection();
+				requestFocus();
+			}
+		}
+		case SWT.MouseEnter -> setHovered(true);
+		case SWT.MouseExit -> setHovered(false);
+		case SWT.KeyDown -> {
+			if (e.keyCode == SWT.SPACE) {
+				setPressed(true);
+				handleSelection();
+				e.doit = false;
+			}
+		}
+		case SWT.KeyUp -> {
+			if (e.keyCode == SWT.SPACE) {
+				setPressed(false);
+				e.doit = false;
 			}
 		}
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWAbstractButton.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWAbstractButton.java
@@ -1,0 +1,88 @@
+package org.eclipse.swt.widgets;
+
+import java.util.*;
+
+import org.eclipse.swt.*;
+
+/**
+ * @author Thomas Singer
+ */
+public abstract class LWAbstractButton extends LWControl {
+
+	public abstract String getAccessibleText();
+
+	protected abstract void handleSelection();
+
+	public static final int EVENT_SELECTED = LWControl.EVENT_NEXT;
+	public static final int EVENT_HOVERED = EVENT_SELECTED + 1;
+	public static final int EVENT_STYLE = EVENT_HOVERED + 1;
+	public static final int EVENT_TEXT = EVENT_STYLE + 1;
+
+	protected int style;
+	private String text;
+	private boolean selected;
+	private boolean hovered;
+
+	protected LWAbstractButton(int style) {
+		this.style = style;
+	}
+
+	public boolean isSelected() {
+		return selected;
+	}
+
+	public void setSelected(boolean selected) {
+		if (selected == this.selected) {
+			return;
+		}
+
+		this.selected = selected;
+		notifyListeners(EVENT_SELECTED);
+	}
+
+	public boolean isHovered() {
+		return hovered;
+	}
+
+	public void setHovered(boolean hovered) {
+		if (hovered == this.hovered) {
+			return;
+		}
+		this.hovered = hovered;
+		notifyListeners(EVENT_HOVERED);
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setText(String text) {
+		if (Objects.equals(text, this.text)) {
+			return;
+		}
+
+		this.text = text;
+		notifyListeners(EVENT_TEXT);
+	}
+
+	public void handleEvent(Event e) {
+		switch (e.type) {
+		case SWT.MouseUp -> {
+			if ((e.stateMask & SWT.BUTTON1) != 0) {
+				handleSelection();
+			}
+		}
+		}
+	}
+
+	public int getStyle() {
+		return style;
+	}
+
+	public void setAlignment(int alignment) {
+		style &= ~(SWT.UP | SWT.DOWN | SWT.LEFT | SWT.CENTER | SWT.RIGHT);
+		style |= alignment
+		         & (SWT.UP | SWT.DOWN | SWT.LEFT | SWT.CENTER | SWT.RIGHT);
+		notifyListeners(EVENT_STYLE);
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWBridge.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWBridge.java
@@ -1,0 +1,199 @@
+package org.eclipse.swt.widgets;
+
+import java.util.*;
+import java.util.List;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+
+/**
+ * @author Thomas Singer
+ */
+public class LWBridge {
+	private final LWContainer container;
+	private final Composite composite;
+
+	private LWControl mouseOverControl;
+	private LWControl focusControl;
+
+	public LWBridge(Composite composite) {
+		this.composite = composite;
+
+		container = new LWContainer(this);
+
+		final Listener listener = event -> {
+			switch (event.type) {
+			case SWT.Paint -> onPaint(event);
+			case SWT.MouseDown -> onMouseDown(event);
+			case SWT.MouseUp -> onMouseUp(event);
+			case SWT.MouseEnter -> onMouseEnter(event);
+			case SWT.MouseMove -> onMouseMove(event);
+			case SWT.MouseExit -> onMouseExit(event);
+			case SWT.FocusIn -> onFocusIn();
+			case SWT.Traverse -> onTraverse(event);
+			case SWT.KeyDown -> onKeyDown(event);
+			case SWT.KeyUp -> onKeyUp(event);
+			}
+		};
+		composite.addListener(SWT.Paint, listener);
+		composite.addListener(SWT.MouseDown, listener);
+		composite.addListener(SWT.MouseUp, listener);
+		composite.addListener(SWT.MouseEnter, listener);
+		composite.addListener(SWT.MouseMove, listener);
+		composite.addListener(SWT.MouseExit, listener);
+		composite.addListener(SWT.FocusIn, listener);
+		composite.addListener(SWT.Traverse, listener);
+		composite.addListener(SWT.KeyDown, listener);
+		composite.addListener(SWT.KeyUp, listener);
+	}
+
+	public LWContainer getContainer() {
+		return container;
+	}
+
+	public void layout() {
+		final MeasureContext measureContext = new MeasureContext(composite);
+		container.layout(measureContext);
+		measureContext.dispose();
+	}
+
+	public void requestFocus(LWControl control) {
+		if (focusControl == control) {
+			return;
+		}
+
+		if (!control.isEnabled() || !control.isVisible() || !control.canBeFocused()) {
+			return;
+		}
+
+		if (focusControl != null) {
+			focusControl.setFocus(false);
+		}
+		focusControl = control;
+		if (focusControl != null) {
+			focusControl.setFocus(true);
+		}
+	}
+
+	public void redraw(int x, int y, int width, int height) {
+		composite.redraw(x, y, width, height, false);
+	}
+
+	private void onPaint(Event event) {
+		final IColorProvider colorProvider = composite.getDisplay().getColorProvider();
+		final Rectangle clipping = event.gc.getClipping();
+		event.gc.fillRectangle(clipping);
+		container.paint(event.gc, colorProvider);
+	}
+
+	private void onMouseDown(Event event) {
+		container.handleEvent(event);
+	}
+
+	private void onMouseUp(Event event) {
+		container.handleEvent(event);
+	}
+
+	private void onMouseEnter(Event event) {
+		mouseOverControl = getControlAt(event);
+		if (mouseOverControl != null) {
+			final Point location = mouseOverControl.getLocationAbsolute();
+			event.x += location.x;
+			event.y += location.y;
+			mouseOverControl.handleEvent(event);
+		}
+	}
+
+	private void onMouseMove(Event event) {
+		final LWControl mouseControl = getControlAt(event);
+		if (mouseControl != mouseOverControl) {
+			if (mouseOverControl != null) {
+				event.type = SWT.MouseExit;
+				mouseOverControl.handleEvent(event);
+			}
+			mouseOverControl = mouseControl;
+			event.type = SWT.MouseEnter;
+		}
+		if (mouseOverControl != null) {
+			mouseOverControl.handleEvent(event);
+		}
+	}
+
+	private void onMouseExit(Event event) {
+		final LWControl mouseControl = getControlAt(event);
+		if (mouseControl != null) {
+			final Point location = mouseControl.getLocationAbsolute();
+			event.x += location.x;
+			event.y += location.y;
+			mouseControl.handleEvent(event);
+		}
+		mouseOverControl = null;
+	}
+
+	private void onFocusIn() {
+		if (focusControl == null) {
+			focusControl = container.getFirstFocusable();
+			if (focusControl != null) {
+				focusControl.setFocus(true);
+			}
+		}
+	}
+
+	private void onTraverse(Event event) {
+		switch (event.detail) {
+		case SWT.TRAVERSE_ARROW_NEXT,
+		     SWT.TRAVERSE_TAB_NEXT -> {
+			final List<LWControl> controls = new ArrayList<>();
+			container.getFocusableControls(controls);
+			final int count = controls.size();
+			if (count == 0) {
+				requestFocus(null);
+				return;
+			}
+
+			final int i = controls.indexOf(focusControl);
+			final int next = (i + 1) % count;
+			requestFocus(controls.get(next));
+		}
+		case SWT.TRAVERSE_ARROW_PREVIOUS,
+		     SWT.TRAVERSE_TAB_PREVIOUS -> {
+			final List<LWControl> controls = new ArrayList<>();
+			container.getFocusableControls(controls);
+			final int count = controls.size();
+			if (count == 0) {
+				requestFocus(null);
+				return;
+			}
+
+			final int i = controls.indexOf(focusControl);
+			final int prev = (i + count - 1) % count;
+			requestFocus(controls.get(prev));
+		}
+		}
+	}
+
+	private void onKeyDown(Event event) {
+		handleKeyEvents(event);
+	}
+
+	private void onKeyUp(Event event) {
+		handleKeyEvents(event);
+	}
+
+	private void handleKeyEvents(Event event) {
+		for (LWControl control = focusControl; control != null; control = control.getParent()) {
+			focusControl.handleEvent(event);
+			if (!event.doit) {
+				break;
+			}
+		}
+	}
+
+	private LWControl getControlAt(Event event) {
+		LWControl control = container.getControlAt(event.x, event.y, true);
+		while (!control.isEnabled()) {
+			control = control.getParent();
+		}
+		return control;
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWButton.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWButton.java
@@ -1,5 +1,6 @@
 package org.eclipse.swt.widgets;
 
+import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 
 /**
@@ -15,6 +16,12 @@ public class LWButton extends LWAbstractButton {
 
 	public LWButton(int style) {
 		super(style);
+		ui = new LWButtonUI(this);
+	}
+
+	public LWButton(String text, LWContainer parent) {
+		super(SWT.PUSH | SWT.CENTER, parent);
+		setText(text);
 		ui = new LWButtonUI(this);
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWButton.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWButton.java
@@ -1,0 +1,64 @@
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.graphics.*;
+
+/**
+ * @author Thomas Singer
+ */
+public class LWButton extends LWAbstractButton {
+
+	private static final int EVENT_IMAGE = LWAbstractButton.EVENT_NEXT;
+
+	private Image image;
+	private Image disabledImage;
+	private LWButtonUI ui;
+
+	public LWButton(int style) {
+		super(style);
+		ui = new LWButtonUI(this);
+	}
+
+	@Override
+	public Point getPreferredSize(IMeasureContext measureContext) {
+		return ui.getPreferredSize(measureContext);
+	}
+
+	@Override
+	public void paint(GC gc, IColorProvider colorProvider) {
+		ui.paint(gc, colorProvider);
+	}
+
+	@Override
+	protected void handleSelection() {
+		setSelected(!isSelected());
+	}
+
+	@Override
+	public String getAccessibleText() {
+		return getText() + " button.\r\n To activate press space bar.";
+	}
+
+	public Image getImage() {
+		return image;
+	}
+
+	public void setImage(Image image) {
+		if (image == this.image) {
+			return;
+		}
+		this.image = image;
+		notifyListeners(EVENT_IMAGE);
+	}
+
+	public void setDisabledImage(Image disabledImage) {
+		if (disabledImage == this.disabledImage) {
+			return;
+		}
+		this.disabledImage = disabledImage;
+		notifyListeners(EVENT_IMAGE);
+	}
+
+	public Image getDisabledImage() {
+		return disabledImage;
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWButtonUI.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWButtonUI.java
@@ -132,6 +132,11 @@ public class LWButtonUI extends LWAbstractButtonUI {
 			int imageTopOffset = (height - imageHeight) / 2;
 			int imageLeftOffset = contentArea.x;
 			if (button.isEnabled()) {
+				if (button.isPressed()) {
+					imageTopOffset++;
+					imageLeftOffset++;
+				}
+
 				gc.drawImage(image, imageLeftOffset, imageTopOffset);
 			}
 			else {
@@ -141,13 +146,18 @@ public class LWButtonUI extends LWAbstractButtonUI {
 
 		// Draw text
 		if (text != null && !text.isEmpty()) {
+			int textTopOffset = (height - 1 - textHeight) / 2;
+			int textLeftOffset = contentArea.x + imageSpace;
 			if (button.isEnabled()) {
 				gc.setForeground(colorProvider.getColor(KEY_TEXT));
+
+				if (button.isPressed()) {
+					textTopOffset++;
+					textLeftOffset++;
+				}
 			} else {
 				gc.setForeground(colorProvider.getColor(KEY_DISABLE));
 			}
-			int textTopOffset = (height - 1 - textHeight) / 2;
-			int textLeftOffset = contentArea.x + imageSpace;
 			gc.drawText(text, textLeftOffset, textTopOffset, DRAW_FLAGS);
 		}
 		if (button.hasFocus()) {
@@ -172,6 +182,11 @@ public class LWButtonUI extends LWAbstractButtonUI {
 				// border ruins center position...
 				centerHeight -= 2;
 				centerWidth -= 2;
+			}
+
+			if (button.isEnabled() && button.isPressed()) {
+				centerHeight++;
+				centerWidth++;
 			}
 
 			// TODO: in the next version use a bezier path

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWButtonUI.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWButtonUI.java
@@ -1,0 +1,246 @@
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+
+/**
+ * @author Thomas Singer
+ */
+public class LWButtonUI extends LWAbstractButtonUI {
+
+	private static final int LEFT_MARGIN = 2;
+	private static final int RIGHT_MARGIN = 2;
+	private static final int TOP_MARGIN = 0;
+	private static final int BOTTOM_MARGIN = 0;
+	private static final int SPACING = 4;
+	private static final int BOX_SIZE = 12;
+	private static final int DRAW_FLAGS = SWT.DRAW_MNEMONIC | SWT.DRAW_TAB
+	                                      | SWT.DRAW_TRANSPARENT | SWT.DRAW_DELIMITER;
+
+	private final LWButton button;
+
+	public LWButtonUI(LWButton button) {
+		this.button = button;
+	}
+
+	public Point getPreferredSize(IMeasureContext mc) {
+		final String text = button.getText();
+		final Image image = button.getImage();
+		final int style = button.getStyle();
+
+		if (isArrowButton()) {
+			int borderWidth = hasBorder() ? 8 : 0;
+			int width = 14 + borderWidth;
+			int height = width;
+
+			return new Point(width, height);
+		}
+
+		int textWidth = 0;
+		int textHeight = 0;
+		int boxSpace = 0;
+		if ((style & (SWT.PUSH | SWT.TOGGLE)) == 0) {
+			boxSpace = BOX_SIZE + SPACING;
+		}
+		if (text != null && !text.isEmpty()) {
+			Point textExtent = mc.textExtent(text, DRAW_FLAGS);
+			textWidth = textExtent.x + 1;
+			textHeight = textExtent.y;
+		}
+		int imageSpace = 0;
+		int imageHeight = 0;
+		if (image != null) {
+			Rectangle imgB = image.getBounds();
+			imageHeight = imgB.height;
+			imageSpace = imgB.width;
+			if (text != null && !text.isEmpty()) {
+				imageSpace += SPACING;
+			}
+		}
+
+		int width = LEFT_MARGIN + boxSpace + imageSpace + textWidth + 1
+		            + RIGHT_MARGIN;
+		int height = TOP_MARGIN
+		             + Math.max(boxSpace, Math.max(textHeight, imageHeight))
+		             + BOTTOM_MARGIN;
+
+		if ((style & (SWT.PUSH | SWT.TOGGLE)) != 0) {
+			width += 12;
+			height += 10;
+		}
+		return new Point(width, height);
+	}
+
+	public void paint(GC gc, IColorProvider colorProvider) {
+		final int width = button.getWidth();
+		final int height = button.getHeight();
+		final String text = button.getText();
+		final int style = button.getStyle();
+		final Image image = button.getImage();
+
+		boolean isRightAligned = (style & SWT.RIGHT) != 0;
+		boolean isCentered = (style & SWT.CENTER) != 0;
+		boolean isPushOrToggleButton = (style & (SWT.PUSH | SWT.TOGGLE)) != 0;
+		int initialAntiAlias = gc.getAntialias();
+
+		int boxSpace = 0;
+		// Draw check box / radio box / push button border
+		if (isPushOrToggleButton) {
+			drawPushButton(gc, 0, 0, width - 1, height - 1, colorProvider);
+		} else {
+			boxSpace = BOX_SIZE + SPACING;
+			int boxLeftOffset = LEFT_MARGIN;
+			int boxTopOffset = (height - 1 - BOX_SIZE) / 2;
+		}
+
+		gc.setAntialias(initialAntiAlias);
+		gc.setAdvanced(false);
+
+		// Calculate area for button content (image + text)
+		int horizontalSpaceForContent = width - RIGHT_MARGIN - LEFT_MARGIN - boxSpace;
+		int textWidth = 0;
+		int textHeight = 0;
+		if (text != null && !text.isEmpty()) {
+			Point textExtent = gc.textExtent(text, DRAW_FLAGS);
+			textWidth = textExtent.x;
+			textHeight = textExtent.y;
+		}
+		int imageSpace = 0;
+		int imageWidth = 0;
+		int imageHeight = 0;
+		if (image != null) {
+			Rectangle imgB = image.getBounds();
+			imageWidth = imgB.width;
+			imageHeight = imgB.height;
+			imageSpace = imageWidth;
+			if (text != null && !text.isEmpty()) {
+				imageSpace += SPACING;
+			}
+		}
+		Rectangle contentArea = new Rectangle(LEFT_MARGIN + boxSpace,
+		                                      TOP_MARGIN, imageSpace + textWidth,
+		                                      height - TOP_MARGIN - BOTTOM_MARGIN);
+		if (isRightAligned) {
+			contentArea.x += horizontalSpaceForContent - contentArea.width;
+		} else if (isCentered) {
+			contentArea.x += (horizontalSpaceForContent - contentArea.width)
+			                 / 2;
+		}
+
+		// Draw image
+		if (image != null) {
+			int imageTopOffset = (height - imageHeight) / 2;
+			int imageLeftOffset = contentArea.x;
+			if (button.isEnabled()) {
+				gc.drawImage(image, imageLeftOffset, imageTopOffset);
+			}
+			else {
+				gc.drawImage(button.getDisabledImage(), imageLeftOffset, imageTopOffset);
+			}
+		}
+
+		// Draw text
+		if (text != null && !text.isEmpty()) {
+			if (button.isEnabled()) {
+				gc.setForeground(colorProvider.getColor(KEY_TEXT));
+			} else {
+				gc.setForeground(colorProvider.getColor(KEY_DISABLE));
+			}
+			int textTopOffset = (height - 1 - textHeight) / 2;
+			int textLeftOffset = contentArea.x + imageSpace;
+			gc.drawText(text, textLeftOffset, textTopOffset, DRAW_FLAGS);
+		}
+		if (button.hasFocus()) {
+			if (((style & SWT.RADIO) | (style & SWT.CHECK)) != 0) {
+				int textTopOffset = (height - 1 - textHeight) / 2;
+				int textLeftOffset = contentArea.x + imageSpace;
+				gc.drawFocus(textLeftOffset - 2, textTopOffset, textWidth + 4,
+				             textHeight);
+			} else {
+				gc.drawFocus(3, 3, width - 7, height - 7);
+			}
+		}
+
+		if (isArrowButton()) {
+			Color bg2 = gc.getBackground();
+
+			gc.setBackground(colorProvider.getColor(KEY_ARROW));
+
+			int centerHeight = height / 2;
+			int centerWidth = width / 2;
+			if (hasBorder()) {
+				// border ruins center position...
+				centerHeight -= 2;
+				centerWidth -= 2;
+			}
+
+			// TODO: in the next version use a bezier path
+
+			int[] curve = null;
+
+			if ((style & SWT.DOWN) != 0) {
+				curve = new int[]{centerWidth, centerHeight + 5,
+				                  centerWidth - 5, centerHeight - 5, centerWidth + 5,
+				                  centerHeight - 5};
+
+			} else if ((style & SWT.LEFT) != 0) {
+				curve = new int[]{centerWidth - 5, centerHeight,
+				                  centerWidth + 5, centerHeight + 5, centerWidth + 5,
+				                  centerHeight - 5};
+
+			} else if ((style & SWT.RIGHT) != 0) {
+				curve = new int[]{centerWidth + 5, centerHeight,
+				                  centerWidth - 5, centerHeight - 5, centerWidth - 5,
+				                  centerHeight + 5};
+
+			} else {
+				curve = new int[]{centerWidth, centerHeight - 5,
+				                  centerWidth - 5, centerHeight + 5, centerWidth + 5,
+				                  centerHeight + 5};
+			}
+
+			gc.fillPolygon(curve);
+			gc.setBackground(bg2);
+		}
+	}
+
+	private boolean hasBorder() {
+		return (button.getStyle() & SWT.BORDER) != 0;
+	}
+
+	private void drawPushButton(GC gc, int x, int y, int w, int h, IColorProvider colorProvider) {
+		final int style = button.getStyle();
+		if (button.isEnabled()) {
+			if ((style & SWT.TOGGLE) != 0 && button.isSelected()) {
+				gc.setBackground(colorProvider.getColor(KEY_TOGGLE));
+			} else if (button.isHovered()) {
+				gc.setBackground(colorProvider.getColor(KEY_HOVER));
+			} else {
+				gc.setBackground(colorProvider.getColor(KEY_BUTTON));
+			}
+			gc.fillRoundRectangle(x, y, w, h, 6, 6);
+		}
+
+		if (button.isEnabled()) {
+			if ((style & SWT.TOGGLE) != 0 && button.isSelected() || button.isHovered()) {
+				gc.setForeground(colorProvider.getColor(KEY_SELECTION));
+			} else {
+				gc.setForeground(colorProvider.getColor(KEY_OUTLINE));
+			}
+		} else {
+			gc.setForeground(colorProvider.getColor(KEY_DISABLE));
+		}
+
+		// if the button has focus, the border also changes the color
+		Color fg = gc.getForeground();
+		if (button.hasFocus()) {
+			gc.setForeground(colorProvider.getColor(KEY_SELECTION));
+		}
+		gc.drawRoundRectangle(x, y, w - 1, h - 1, 6, 6);
+		gc.setForeground(fg);
+	}
+
+	private boolean isArrowButton() {
+		return (button.getStyle() & SWT.ARROW) != 0;
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWCheckbox.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWCheckbox.java
@@ -1,0 +1,51 @@
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.graphics.*;
+
+/**
+ * @author Thomas Singer
+ */
+public class LWCheckbox extends LWAbstractButton {
+
+	private static final int EVENT_GRAYED = LWAbstractButton.EVENT_NEXT;
+
+	private boolean grayed;
+	private LWCheckboxUI ui;
+
+	public LWCheckbox(int style) {
+		super(style);
+		ui = new LWCheckboxUI(this);
+	}
+
+	@Override
+	public Point getPreferredSize(IMeasureContext measureContext) {
+		return ui.getPreferredSize(measureContext);
+	}
+
+	@Override
+	public void paint(GC gc, IColorProvider colorProvider) {
+		ui.paint(gc, colorProvider);
+	}
+
+	@Override
+	protected void handleSelection() {
+		setSelected(!isSelected());
+	}
+
+	@Override
+	public String getAccessibleText() {
+		return getText();
+	}
+
+	public boolean isGrayed() {
+		return grayed;
+	}
+
+	public void setGrayed(boolean grayed) {
+		if (grayed == this.grayed) {
+			return;
+		}
+		this.grayed = grayed;
+		notifyListeners(EVENT_GRAYED);
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWCheckboxUI.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWCheckboxUI.java
@@ -1,0 +1,123 @@
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+
+/**
+ * @author Thomas Singer
+ */
+public class LWCheckboxUI extends LWAbstractButtonUI {
+
+	private static final int LEFT_MARGIN = 2;
+	private static final int RIGHT_MARGIN = 2;
+	private static final int TOP_MARGIN = 0;
+	private static final int BOTTOM_MARGIN = 0;
+	private static final int SPACING = 4;
+	private static final int BOX_SIZE = 12;
+	private static final int DRAW_FLAGS = SWT.DRAW_MNEMONIC | SWT.DRAW_TAB
+	                                      | SWT.DRAW_TRANSPARENT | SWT.DRAW_DELIMITER;
+
+	private final LWCheckbox button;
+
+	public LWCheckboxUI(LWCheckbox button) {
+		this.button = button;
+	}
+
+	public Point getPreferredSize(IMeasureContext mc) {
+		final String text = button.getText();
+
+		int textWidth = 0;
+		int textHeight = 0;
+		int boxSpace = BOX_SIZE + SPACING;
+		if (text != null && !text.isEmpty()) {
+			Point textExtent = mc.textExtent(text, DRAW_FLAGS);
+			textWidth = textExtent.x + 1;
+			textHeight = textExtent.y;
+		}
+		int imageSpace = 0;
+		int imageHeight = 0;
+
+		int width = LEFT_MARGIN + boxSpace + imageSpace + textWidth + 1 + RIGHT_MARGIN;
+		int height = TOP_MARGIN
+		             + Math.max(boxSpace, Math.max(textHeight, imageHeight))
+		             + BOTTOM_MARGIN;
+		return new Point(width, height);
+	}
+
+	public void paint(GC gc, IColorProvider colorProvider) {
+		final int width = button.getWidth();
+		final int height = button.getHeight();
+		final String text = button.getText();
+
+		boolean isRightAligned = false;
+		boolean isCentered = false;
+		boolean isPushOrToggleButton = false;
+		int initialAntiAlias = gc.getAntialias();
+
+		int boxSpace = BOX_SIZE + SPACING;
+		int boxLeftOffset = LEFT_MARGIN;
+		int boxTopOffset = (height - 1 - BOX_SIZE) / 2;
+		drawCheckbox(gc, boxLeftOffset, boxTopOffset, colorProvider);
+
+		gc.setAntialias(initialAntiAlias);
+		gc.setAdvanced(false);
+
+		// Calculate area for button content (image + text)
+		int horizontalSpaceForContent = width - RIGHT_MARGIN - LEFT_MARGIN - boxSpace;
+		int textWidth = 0;
+		int textHeight = 0;
+		if (text != null && !text.isEmpty()) {
+			Point textExtent = gc.textExtent(text, DRAW_FLAGS);
+			textWidth = textExtent.x;
+			textHeight = textExtent.y;
+		}
+		int imageSpace = 0;
+		int imageWidth = 0;
+		int imageHeight = 0;
+		Rectangle contentArea = new Rectangle(LEFT_MARGIN + boxSpace,
+		                                      TOP_MARGIN, imageSpace + textWidth,
+		                                      height - TOP_MARGIN - BOTTOM_MARGIN);
+
+		// Draw text
+		if (text != null && !text.isEmpty()) {
+			if (button.isEnabled()) {
+				gc.setForeground(colorProvider.getColor(KEY_TEXT));
+			} else {
+				gc.setForeground(colorProvider.getColor(KEY_DISABLE));
+			}
+			int textTopOffset = (height - 1 - textHeight) / 2;
+			int textLeftOffset = contentArea.x + imageSpace;
+			gc.drawText(text, textLeftOffset, textTopOffset, DRAW_FLAGS);
+		}
+		if (button.hasFocus()) {
+			int textTopOffset = (height - 1 - textHeight) / 2;
+			int textLeftOffset = contentArea.x + imageSpace;
+			gc.drawFocus(textLeftOffset - 2, textTopOffset, textWidth + 4, textHeight);
+		}
+	}
+
+	private void drawCheckbox(GC gc, int x, int y, IColorProvider colorProvider) {
+		if (button.isSelected()) {
+			if (button.isGrayed()) {
+				gc.setBackground(colorProvider.getColor(KEY_TRISTATE));
+			} else {
+				gc.setBackground(colorProvider.getColor(KEY_SELECTION));
+			}
+			int partialBoxBorder = 2;
+			gc.fillRoundRectangle(x + partialBoxBorder, y + partialBoxBorder,
+			                      BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1,
+			                      BOX_SIZE / 4 - partialBoxBorder / 2,
+			                      BOX_SIZE / 4 - partialBoxBorder / 2);
+
+		}
+		if (button.isHovered()) {
+			gc.setBackground(colorProvider.getColor(KEY_HOVER));
+			int partialBoxBorder = button.isSelected() ? 4 : 0;
+			gc.fillRoundRectangle(x + partialBoxBorder, y + partialBoxBorder,
+			                      BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1,
+			                      BOX_SIZE / 4 - partialBoxBorder / 2,
+			                      BOX_SIZE / 4 - partialBoxBorder / 2);
+		}
+		gc.drawRoundRectangle(x, y, BOX_SIZE, BOX_SIZE, 4, 4);
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWColumnLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWColumnLayout.java
@@ -1,0 +1,96 @@
+package org.eclipse.swt.widgets;
+
+import java.util.*;
+import java.util.List;
+
+import org.eclipse.swt.graphics.*;
+
+/**
+ * @author Thomas Singer
+ */
+public class LWColumnLayout implements LWLayoutManager {
+
+	private final Alignment alignment;
+
+	private int marginLeft;
+	private int marginTop;
+	private int marginRight;
+	private int marginBottom;
+	private int spacing;
+
+	public LWColumnLayout(Alignment alignment) {
+		this.alignment = Objects.requireNonNull(alignment);
+	}
+
+	@Override
+	public Point getPreferredSize(List<LWControl> children, IMeasureContext measureContext) {
+		int maxWidth = 0;
+		int heightSum = 0;
+		for (LWControl child : children) {
+			if (heightSum > 0) {
+				heightSum += spacing;
+			}
+			final Point preferredSize = child.getPreferredSize(measureContext);
+			heightSum += preferredSize.y;
+			maxWidth = Math.max(preferredSize.x, maxWidth);
+		}
+		return new Point(marginLeft + maxWidth + marginRight,
+		                 marginTop + heightSum + marginBottom);
+	}
+
+	@Override
+	public void layout(List<LWControl> children, Point size, IMeasureContext measureContext) {
+		int maxWidth = 0;
+		for (LWControl child : children) {
+			final Point preferredSize = child.getPreferredSize(measureContext);
+			child.setSize(preferredSize);
+			maxWidth = Math.max(preferredSize.x, maxWidth);
+		}
+
+		int y = marginTop;
+		for (LWControl child : children) {
+			final int width = child.getWidth();
+			Alignment alignment = this.alignment;
+			if (child.getLayoutData() instanceof Alignment controlAlignment) {
+				alignment = controlAlignment;
+			}
+			final int x = switch (alignment) {
+				case BEGIN -> 0;
+				case CENTER -> (maxWidth - width) / 2;
+				case END -> maxWidth - width;
+				case FILL -> {
+					child.setSize(maxWidth, child.getHeight());
+					yield 0;
+				}
+			} + marginLeft;
+			child.setLocation(x, y);
+			y += child.getHeight();
+			y += spacing;
+		}
+	}
+
+	public LWColumnLayout setMargin(int all) {
+		return setMargin(all, all);
+	}
+
+	public LWColumnLayout setMargin(int leftRight, int topBottom) {
+		return setMargin(leftRight, topBottom, leftRight, topBottom);
+	}
+
+	public LWColumnLayout setMargin(int left, int top, int right, int bottom) {
+		marginLeft = left;
+		marginTop = top;
+		marginRight = right;
+		marginBottom = bottom;
+		return this;
+	}
+
+	public LWColumnLayout setSpacing(int spacing) {
+		this.spacing = spacing;
+		return this;
+	}
+
+	public enum Alignment {
+		BEGIN, CENTER, FILL, END
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWContainer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWContainer.java
@@ -1,0 +1,175 @@
+package org.eclipse.swt.widgets;
+
+import java.util.*;
+import java.util.List;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+
+/**
+ * @author Thomas Singer
+ */
+public class LWContainer extends LWControl {
+
+	private final List<LWControl> children = new ArrayList<>();
+	private final LWBridge bridge;
+
+	private LWLayoutManager layoutManager;
+
+	public LWContainer(LWBridge bridge) {
+		super(null);
+		this.bridge = bridge;
+	}
+
+	@Override
+	public Point getPreferredSize(IMeasureContext measureContext) {
+		if (layoutManager != null) {
+			return layoutManager.getPreferredSize(getChildren(), measureContext);
+		}
+		return new Point(0, 0);
+	}
+
+	@Override
+	public void paint(GC gc, IColorProvider colorProvider) {
+		final Rectangle clipping = gc.getClipping();
+		for (LWControl child : children) {
+			if (!child.isVisible()) {
+				continue;
+			}
+
+			final Rectangle bounds = child.getBounds();
+			if (!bounds.intersects(clipping)) {
+				continue;
+			}
+
+			gc.transform(bounds.x, bounds.y);
+			try {
+/*
+				gc.setClipping(clipping.x - bounds.x, clipping.y - bounds.y,
+				               clipping.width, clipping.height);
+*/
+				child.paint(gc, colorProvider);
+			}
+			finally {
+				gc.transform(-bounds.x, -bounds.y);
+			}
+		}
+	}
+
+	@Override
+	public void handleEvent(Event event) {
+		switch (event.type) {
+		case SWT.MouseDown,
+		     SWT.MouseEnter,
+		     SWT.MouseExit,
+		     SWT.MouseMove,
+		     SWT.MouseUp -> handleMouseEvent(event);
+		}
+	}
+
+	@Override
+	protected LWBridge getBridge() {
+		return bridge;
+	}
+
+	public void add(LWControl control) {
+		if (children.contains(control)) {
+			throw new IllegalArgumentException("duplicate");
+		}
+		children.add(control);
+	}
+
+	public List<LWControl> getChildren() {
+		return Collections.unmodifiableList(children);
+	}
+
+	public void setLayoutManager(LWLayoutManager layoutManager) {
+		this.layoutManager = layoutManager;
+	}
+
+	public void layout(IMeasureContext measureContext) {
+		if (layoutManager != null) {
+			layoutManager.layout(getChildren(), getSize(), measureContext);
+		}
+	}
+
+	public LWControl getControlAt(int x, int y, boolean skipInvisible) {
+		for (LWControl child : children) {
+			if (skipInvisible && !child.isVisible()) {
+				continue;
+			}
+
+			final Rectangle bounds = child.getBounds();
+			if (!bounds.contains(x, y)) {
+				continue;
+			}
+
+			if (child instanceof LWContainer container) {
+				return container.getControlAt(x - bounds.x, y - bounds.y, skipInvisible);
+			}
+			return child;
+		}
+		return this;
+	}
+
+	public LWControl getFirstFocusable() {
+		for (LWControl child : children) {
+			if (!child.isVisible() || !child.isEnabled()) {
+				continue;
+			}
+
+			if (child.canBeFocused()) {
+				return child;
+			}
+
+			if (child instanceof LWContainer container) {
+				return container.getFirstFocusable();
+			}
+		}
+		return null;
+	}
+
+	protected LWContainer getRoot() {
+		final LWContainer parent = getParent();
+		if (parent == null) {
+			return this;
+		}
+		return parent.getRoot();
+	}
+
+	public void getFocusableControls(List<LWControl> focusableControls) {
+		for (LWControl child : children) {
+			if (child.canBeFocused()) {
+				focusableControls.add(child);
+			}
+			if (child instanceof LWContainer container) {
+				container.getFocusableControls(focusableControls);
+			}
+		}
+	}
+
+	private void handleMouseEvent(Event event) {
+		for (LWControl child : children) {
+			if (!child.isVisible()) {
+				continue;
+			}
+
+			final Rectangle bounds = child.getBounds();
+			if (!bounds.contains(event.x, event.y)) {
+				continue;
+			}
+
+			final int x = bounds.x;
+			final int y = bounds.y;
+			event.x -= x;
+			event.y -= y;
+			try {
+				child.handleEvent(event);
+			}
+			finally {
+				event.x += x;
+				event.y += y;
+			}
+		}
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWControl.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWControl.java
@@ -1,0 +1,110 @@
+package org.eclipse.swt.widgets;
+
+import java.util.*;
+import java.util.List;
+
+import org.eclipse.swt.graphics.*;
+
+/**
+ * @author Thomas Singer
+ */
+public abstract class LWControl {
+
+	public static final int EVENT_SIZE = 0;
+	public static final int EVENT_ENABLED = EVENT_SIZE + 1;
+	public static final int EVENT_VISIBLE = EVENT_ENABLED + 1;
+	public static final int EVENT_FOCUS = EVENT_VISIBLE + 1;
+	protected static final int EVENT_NEXT = EVENT_FOCUS + 1;
+
+	public abstract Point getPreferredSize(IMeasureContext measureContext);
+
+	public abstract void paint(GC gc, IColorProvider colorProvider);
+
+	private final List<Listener> listeners = new ArrayList<>();
+
+	private int width;
+	private int height;
+	private boolean enabled = true;
+	private boolean visible = true;
+	private boolean hasFocus;
+
+	protected LWControl() {
+	}
+
+	public Point getSize() {
+		return new Point(width, height);
+	}
+
+	public int getWidth() {
+		return width;
+	}
+
+	public int getHeight() {
+		return height;
+	}
+
+	public void setSize(int width, int height) {
+		if (width == this.width && height == this.height) {
+			return;
+		}
+
+		this.width = width;
+		this.height = height;
+		notifyListeners(EVENT_SIZE);
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		if (enabled == this.enabled) {
+			return;
+		}
+
+		this.enabled = enabled;
+		notifyListeners(EVENT_ENABLED);
+	}
+
+	public boolean isVisible() {
+		return visible;
+	}
+
+	public void setVisible(boolean visible) {
+		if (visible == this.visible) {
+			return;
+		}
+
+		this.visible = visible;
+		notifyListeners(EVENT_VISIBLE);
+	}
+
+	public boolean hasFocus() {
+		return hasFocus;
+	}
+
+	public void setHasFocus(boolean hasFocus) {
+		if (hasFocus == this.hasFocus) {
+			return;
+		}
+
+		this.hasFocus = hasFocus;
+		notifyListeners(EVENT_FOCUS);
+	}
+
+	public void addListener(Listener listener) {
+		Objects.requireNonNull(listener);
+
+		listeners.add(listener);
+	}
+
+	protected final void notifyListeners(int type) {
+		for (Listener listener : new ArrayList<>(listeners)) {
+			listener.handleEvent(type);
+		}
+	}
+
+	public interface Listener {
+		void handleEvent(int type);
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWControl.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWControl.java
@@ -10,29 +10,42 @@ import org.eclipse.swt.graphics.*;
  */
 public abstract class LWControl {
 
-	public static final int EVENT_SIZE = 0;
-	public static final int EVENT_ENABLED = EVENT_SIZE + 1;
-	public static final int EVENT_VISIBLE = EVENT_ENABLED + 1;
-	public static final int EVENT_FOCUS = EVENT_VISIBLE + 1;
-	protected static final int EVENT_NEXT = EVENT_FOCUS + 1;
-
 	public abstract Point getPreferredSize(IMeasureContext measureContext);
 
 	public abstract void paint(GC gc, IColorProvider colorProvider);
 
-	private final List<Listener> listeners = new ArrayList<>();
+	public static final int EVENT_SIZE = 0;
+	public static final int EVENT_LOCATION = EVENT_SIZE + 1;
+	public static final int EVENT_ENABLED = EVENT_LOCATION + 1;
+	public static final int EVENT_VISIBLE = EVENT_ENABLED + 1;
+	public static final int EVENT_FOCUS = EVENT_VISIBLE + 1;
+	protected static final int EVENT_NEXT = EVENT_FOCUS + 1;
 
+	private final List<Listener> listeners = new ArrayList<>();
+	private final LWContainer parent;
+
+	private int x;
+	private int y;
 	private int width;
 	private int height;
 	private boolean enabled = true;
 	private boolean visible = true;
 	private boolean hasFocus;
+	private Object layoutData;
 
-	protected LWControl() {
+	protected LWControl(LWContainer parent) {
+		this.parent = parent;
+		if (parent != null) {
+			parent.add(this);
+		}
 	}
 
 	public Point getSize() {
 		return new Point(width, height);
+	}
+
+	public void setSize(Point size) {
+		setSize(size.x, size.y);
 	}
 
 	public int getWidth() {
@@ -51,6 +64,40 @@ public abstract class LWControl {
 		this.width = width;
 		this.height = height;
 		notifyListeners(EVENT_SIZE);
+	}
+
+	public int getX() {
+		return x;
+	}
+
+	public int getY() {
+		return y;
+	}
+
+	public Point getLocation() {
+		return new Point(x, y);
+	}
+
+	public void setLocation(int x, int y) {
+		if (x == this.x && y == this.y) {
+			return;
+		}
+		this.x = x;
+		this.y = y;
+		notifyListeners(EVENT_LOCATION);
+	}
+
+	public Point getLocationAbsolute() {
+		final Point location = new Point(x, y);
+		for (LWContainer parent = this.parent; parent != null; parent = ((LWControl)parent).parent) {
+			location.x += parent.getX();
+			location.y += parent.getY();
+		}
+		return location;
+	}
+
+	public Rectangle getBounds() {
+		return new Rectangle(x, y, width, height);
 	}
 
 	public boolean isEnabled() {
@@ -79,10 +126,6 @@ public abstract class LWControl {
 		notifyListeners(EVENT_VISIBLE);
 	}
 
-	public boolean hasFocus() {
-		return hasFocus;
-	}
-
 	public void setHasFocus(boolean hasFocus) {
 		if (hasFocus == this.hasFocus) {
 			return;
@@ -92,16 +135,88 @@ public abstract class LWControl {
 		notifyListeners(EVENT_FOCUS);
 	}
 
+	public LWContainer getParent() {
+		return parent;
+	}
+
+	public void redraw() {
+		redraw(0, 0, width, height);
+	}
+
+	public void redraw(int x, int y, int width, int height) {
+		if (parent != null) {
+			parent.redraw(x + this.x, y + this.y, width, height);
+		}
+		else {
+			final LWBridge bridge = getBridge();
+			if (bridge != null) {
+				bridge.redraw(x, y, width, height);
+			}
+		}
+	}
+
+	public Object getLayoutData() {
+		return layoutData;
+	}
+
+	public void setLayoutData(Object layoutData) {
+		this.layoutData = layoutData;
+	}
+
+	public boolean hasFocus() {
+		return hasFocus;
+	}
+
+	public void setFocus(boolean hasFocus) {
+		if (hasFocus == this.hasFocus) {
+			return;
+		}
+		this.hasFocus = hasFocus;
+		notifyListeners(EVENT_FOCUS);
+	}
+
+	protected boolean canBeFocused() {
+		return isVisible() && isEnabled();
+	}
+
+
 	public void addListener(Listener listener) {
 		Objects.requireNonNull(listener);
 
 		listeners.add(listener);
 	}
 
-	protected final void notifyListeners(int type) {
+	protected void notifyListeners(int type) {
 		for (Listener listener : new ArrayList<>(listeners)) {
 			listener.handleEvent(type);
 		}
+	}
+
+	protected void handleEvent(Event event) {
+	}
+
+	public void requestFocus() {
+		final LWBridge bridge = getBridge();
+		if (bridge == null) {
+			return;
+		}
+
+		bridge.requestFocus(this);
+	}
+
+	protected LWBridge getBridge() {
+		final LWContainer root = getRoot();
+		if (root == null) {
+			return null;
+		}
+		return root.getBridge();
+	}
+
+	private LWContainer getRoot() {
+		if (parent == null) {
+			return null;
+		}
+		return parent.getRoot();
 	}
 
 	public interface Listener {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWLayoutManager.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWLayoutManager.java
@@ -1,0 +1,14 @@
+package org.eclipse.swt.widgets;
+
+import java.util.List;
+
+import org.eclipse.swt.graphics.*;
+
+/**
+ * @author Thomas Singer
+ */
+public interface LWLayoutManager {
+	Point getPreferredSize(List<LWControl> children, IMeasureContext measureContext);
+
+	void layout(List<LWControl> children, Point size, IMeasureContext measureContext);
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWRadioButton.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWRadioButton.java
@@ -14,6 +14,15 @@ public class LWRadioButton extends LWAbstractButton {
 
 	private LWRadioButtonUI ui;
 
+	public LWRadioButton(String text, Group group, LWContainer container) {
+		super(0, container);
+		this.group = group;
+		group.add(this);
+		setText(text);
+
+		ui = new LWRadioButtonUI(this);
+	}
+
 	public LWRadioButton(int style, Group group) {
 		super(style);
 		this.group = Objects.requireNonNull(group);
@@ -39,14 +48,7 @@ public class LWRadioButton extends LWAbstractButton {
 
 	@Override
 	protected void handleSelection() {
-		final List<LWRadioButton> buttons = group.getRadioButtons();
-		for (LWRadioButton button : buttons) {
-			if (button != this) {
-				button.setSelected(false);
-			}
-		}
-
-		setSelected(true);
+		setSelected();
 	}
 
 	@Override
@@ -65,9 +67,38 @@ public class LWRadioButton extends LWAbstractButton {
 		return buffer.toString();
 	}
 
+	public void setSelected() {
+		final List<LWRadioButton> buttons = group.getRadioButtons();
+		for (LWRadioButton button : buttons) {
+			if (button != this) {
+				button.setSelected(false);
+			}
+		}
+
+		setSelected(true);
+	}
+
 	public interface Group {
 		void add(LWRadioButton radioButton);
 
 		List<LWRadioButton> getRadioButtons();
+	}
+
+	public static class DefaultGroup implements Group {
+		private final List<LWRadioButton> buttons = new ArrayList<>();
+
+		@Override
+		public void add(LWRadioButton button) {
+			if (buttons.contains(button)) {
+				throw new IllegalArgumentException("duplicate");
+			}
+
+			buttons.add(button);
+		}
+
+		@Override
+		public List<LWRadioButton> getRadioButtons() {
+			return Collections.unmodifiableList(buttons);
+		}
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWRadioButton.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWRadioButton.java
@@ -1,0 +1,73 @@
+package org.eclipse.swt.widgets;
+
+import java.util.*;
+import java.util.List;
+
+import org.eclipse.swt.graphics.*;
+
+/**
+ * @author Thomas Singer
+ */
+public class LWRadioButton extends LWAbstractButton {
+
+	private final Group group;
+
+	private LWRadioButtonUI ui;
+
+	public LWRadioButton(int style, Group group) {
+		super(style);
+		this.group = Objects.requireNonNull(group);
+		group.add(this);
+
+		ui = new LWRadioButtonUI(this);
+	}
+
+	@Override
+	public String toString() {
+		return "RadioButton '" + getText() + "'";
+	}
+
+	@Override
+	public Point getPreferredSize(IMeasureContext measureContext) {
+		return ui.getPreferredSize(measureContext);
+	}
+
+	@Override
+	public void paint(GC gc, IColorProvider colorProvider) {
+		ui.paint(gc, colorProvider);
+	}
+
+	@Override
+	protected void handleSelection() {
+		final List<LWRadioButton> buttons = group.getRadioButtons();
+		for (LWRadioButton button : buttons) {
+			if (button != this) {
+				button.setSelected(false);
+			}
+		}
+
+		setSelected(true);
+	}
+
+	@Override
+	public String getAccessibleText() {
+		final List<LWRadioButton> buttons = group.getRadioButtons();
+		final int index = buttons.indexOf(this) + 1;
+
+		final StringBuilder buffer = new StringBuilder();
+		buffer.append(getText());
+		buffer.append(" radio button checked.\r\n");
+		buffer.append(index);
+		buffer.append(" of ");
+		buffer.append(buttons.size());
+		buffer.append(".\r\n ");
+		buffer.append("To change the selection press Up or Down Arrow.");
+		return buffer.toString();
+	}
+
+	public interface Group {
+		void add(LWRadioButton radioButton);
+
+		List<LWRadioButton> getRadioButtons();
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWRadioButtonUI.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWRadioButtonUI.java
@@ -39,7 +39,7 @@ public class LWRadioButtonUI extends LWAbstractButtonUI {
 
 		int width = LEFT_MARGIN + boxSpace + imageSpace + textWidth + 1 + RIGHT_MARGIN;
 		int height = TOP_MARGIN
-		             + Math.max(boxSpace, Math.max(textHeight, imageHeight))
+		             + Math.max(boxSpace, Math.max(textHeight + 2, imageHeight))
 		             + BOTTOM_MARGIN;
 		return new Point(width, height);
 	}
@@ -89,8 +89,12 @@ public class LWRadioButtonUI extends LWAbstractButtonUI {
 		if (button.hasFocus()) {
 			int textTopOffset = (height - 1 - textHeight) / 2;
 			int textLeftOffset = contentArea.x + imageSpace;
+/*
 			gc.drawFocus(textLeftOffset - 2, textTopOffset,
-			             textWidth + 4, textHeight);
+			             textWidth + 4, textHeight - 1);
+*/
+			gc.drawRectangle(textLeftOffset - 2, textTopOffset,
+			             textWidth + 4, textHeight - 1);
 		}
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWRadioButtonUI.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWRadioButtonUI.java
@@ -1,0 +1,115 @@
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+
+/**
+ * @author Thomas Singer
+ */
+public class LWRadioButtonUI extends LWAbstractButtonUI {
+
+	private static final int LEFT_MARGIN = 2;
+	private static final int RIGHT_MARGIN = 2;
+	private static final int TOP_MARGIN = 0;
+	private static final int BOTTOM_MARGIN = 0;
+	private static final int SPACING = 4;
+	private static final int BOX_SIZE = 12;
+	private static final int DRAW_FLAGS = SWT.DRAW_MNEMONIC | SWT.DRAW_TAB
+	                                      | SWT.DRAW_TRANSPARENT | SWT.DRAW_DELIMITER;
+
+	private final LWRadioButton button;
+
+	public LWRadioButtonUI(LWRadioButton button) {
+		this.button = button;
+	}
+
+	public Point getPreferredSize(IMeasureContext mc) {
+		final String text = button.getText();
+
+		int textWidth = 0;
+		int textHeight = 0;
+		int boxSpace = BOX_SIZE + SPACING;
+		if (text != null && !text.isEmpty()) {
+			Point textExtent = mc.textExtent(text, DRAW_FLAGS);
+			textWidth = textExtent.x + 1;
+			textHeight = textExtent.y;
+		}
+		int imageSpace = 0;
+		int imageHeight = 0;
+
+		int width = LEFT_MARGIN + boxSpace + imageSpace + textWidth + 1 + RIGHT_MARGIN;
+		int height = TOP_MARGIN
+		             + Math.max(boxSpace, Math.max(textHeight, imageHeight))
+		             + BOTTOM_MARGIN;
+		return new Point(width, height);
+	}
+
+	public void paint(GC gc, IColorProvider colorProvider) {
+		final int width = button.getWidth();
+		final int height = button.getHeight();
+		final String text = button.getText();
+
+		int initialAntiAlias = gc.getAntialias();
+
+		int boxSpace = BOX_SIZE + SPACING;
+		int boxLeftOffset = LEFT_MARGIN;
+		int boxTopOffset = (height - 1 - BOX_SIZE) / 2;
+		drawRadioButton(gc, boxLeftOffset, boxTopOffset, colorProvider);
+
+		gc.setAntialias(initialAntiAlias);
+		gc.setAdvanced(false);
+
+		// Calculate area for button content (image + text)
+		int horizontalSpaceForContent = width - RIGHT_MARGIN - LEFT_MARGIN - boxSpace;
+		int textWidth = 0;
+		int textHeight = 0;
+		if (text != null && !text.isEmpty()) {
+			Point textExtent = gc.textExtent(text, DRAW_FLAGS);
+			textWidth = textExtent.x;
+			textHeight = textExtent.y;
+		}
+		int imageSpace = 0;
+		int imageWidth = 0;
+		int imageHeight = 0;
+		Rectangle contentArea = new Rectangle(LEFT_MARGIN + boxSpace,
+		                                      TOP_MARGIN, imageSpace + textWidth,
+		                                      height - TOP_MARGIN - BOTTOM_MARGIN);
+
+		// Draw text
+		if (text != null && !text.isEmpty()) {
+			if (button.isEnabled()) {
+				gc.setForeground(colorProvider.getColor(KEY_TEXT));
+			} else {
+				gc.setForeground(colorProvider.getColor(KEY_DISABLE));
+			}
+			int textTopOffset = (height - 1 - textHeight) / 2;
+			int textLeftOffset = contentArea.x + imageSpace;
+			gc.drawText(text, textLeftOffset, textTopOffset, DRAW_FLAGS);
+		}
+		if (button.hasFocus()) {
+			int textTopOffset = (height - 1 - textHeight) / 2;
+			int textLeftOffset = contentArea.x + imageSpace;
+			gc.drawFocus(textLeftOffset - 2, textTopOffset,
+			             textWidth + 4, textHeight);
+		}
+	}
+
+	private void drawRadioButton(GC gc, int x, int y, IColorProvider colorProvider) {
+		if (button.isSelected()) {
+			gc.setBackground(colorProvider.getColor(KEY_SELECTION));
+			int partialBoxBorder = 2;
+			gc.fillOval(x + partialBoxBorder, y + partialBoxBorder,
+			            BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1);
+		}
+		if (button.isHovered()) {
+			gc.setBackground(colorProvider.getColor(KEY_HOVER));
+			int partialBoxBorder = button.isSelected() ? 4 : 0;
+			gc.fillOval(x + partialBoxBorder, y + partialBoxBorder,
+			            BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1);
+		}
+		if (!button.isEnabled()) {
+			gc.setForeground(colorProvider.getColor(KEY_DISABLE));
+		}
+		gc.drawOval(x, y, BOX_SIZE, BOX_SIZE);
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWRowLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LWRowLayout.java
@@ -1,0 +1,41 @@
+package org.eclipse.swt.widgets;
+
+import java.util.List;
+
+import org.eclipse.swt.graphics.*;
+
+/**
+ * @author Thomas Singer
+ */
+public class LWRowLayout implements LWLayoutManager {
+
+	@Override
+	public Point getPreferredSize(List<LWControl> children, IMeasureContext measureContext) {
+		int widthSum = 0;
+		int maxHeight = 0;
+		for (LWControl child : children) {
+			final Point preferredSize = child.getPreferredSize(measureContext);
+			widthSum += preferredSize.x;
+			maxHeight = Math.max(preferredSize.y, maxHeight);
+		}
+		return new Point(widthSum, maxHeight);
+	}
+
+	@Override
+	public void layout(List<LWControl> children, Point size, IMeasureContext measureContext) {
+		int maxHeight = 0;
+		for (LWControl child : children) {
+			final Point preferredSize = child.getPreferredSize(measureContext);
+			child.setSize(preferredSize);
+			maxHeight = Math.max(preferredSize.y, maxHeight);
+		}
+
+		int x = 0;
+		for (LWControl child : children) {
+			final int height = child.getHeight();
+			final int y = (maxHeight - height) / 2;
+			child.setLocation(x, y);
+			x += child.getWidth();
+		}
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
@@ -53,13 +53,19 @@ import org.eclipse.swt.graphics.*;
  */
 public class Label extends Control implements ICustomWidget {
 
+	public static final String KEY_DISABLED = "label.disabled"; //$NON-NLS-1$
+	public static final String KEY_SHADOW_IN_LIGHT = "label.shadowIn.light"; //$NON-NLS-1$
+	public static final String KEY_SHADOW_IN_DARK = "label.shadowIn.dark"; //$NON-NLS-1$
+	public static final String KEY_SHADOW_OUT_LIGHT = "label.shadowOut.light"; //$NON-NLS-1$
+	public static final String KEY_SHADOW_OUT_DARK = "label.shadowOut.dark"; //$NON-NLS-1$
+
 	/** Gap between icon and text */
 	private static final int GAP = 5;
 	/** Left and right margins */
 	private static final int DEFAULT_MARGIN = 3;
 	/** a string inserted in the middle of text that has been shortened */
 	private static final String ELLIPSIS = "..."; //$NON-NLS-1$ // could use
-													// the ellipsis glyph on
+	// the ellipsis glyph on
 													// some platforms "\u2026"
 	/** the alignment. Either CENTER, RIGHT, LEFT. Default is LEFT */
 	private int align = SWT.LEFT;
@@ -724,8 +730,9 @@ public class Label extends Control implements ICustomWidget {
 			if (isEnabled()) {
 				gc.setForeground(getForeground());
 			} else {
-				gc.setForeground(getDisplay().getSystemColor(SWT.COLOR_WIDGET_NORMAL_SHADOW));
+				gc.setForeground(getColorProvider().getColor(KEY_DISABLED));
 			}
+
 			for (String line : lines) {
 				int lineX = x;
 				if (lines.length > 1) {
@@ -763,14 +770,15 @@ public class Label extends Control implements ICustomWidget {
 		Color c1 = null;
 		Color c2 = null;
 
+		final IColorProvider colorProvider = getColorProvider();
 		int style = getStyle();
 		if ((style & SWT.SHADOW_IN) != 0) {
-			c1 = disp.getSystemColor(SWT.COLOR_WIDGET_NORMAL_SHADOW);
-			c2 = disp.getSystemColor(SWT.COLOR_WIDGET_HIGHLIGHT_SHADOW);
+			c1 = colorProvider.getColor(KEY_SHADOW_IN_DARK);
+			c2 = colorProvider.getColor(KEY_SHADOW_IN_LIGHT);
 		}
 		if ((style & SWT.SHADOW_OUT) != 0) {
-			c1 = disp.getSystemColor(SWT.COLOR_WIDGET_LIGHT_SHADOW);
-			c2 = disp.getSystemColor(SWT.COLOR_WIDGET_NORMAL_SHADOW);
+			c1 = colorProvider.getColor(KEY_SHADOW_OUT_LIGHT);
+			c2 = colorProvider.getColor(KEY_SHADOW_OUT_DARK);
 		}
 
 		if (c1 != null && c2 != null) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/MeasureContext.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/MeasureContext.java
@@ -1,0 +1,33 @@
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.graphics.*;
+
+/**
+ * @author Thomas Singer
+ */
+final class MeasureContext implements IMeasureContext {
+	private final Control control;
+
+	private GC gc;
+
+	public MeasureContext(Control control) {
+		this.control = control;
+	}
+
+	@Override
+	public Point textExtent(String text, int drawFlags) {
+		if (gc == null) {
+			gc = GCFactory.createGraphicsContext(control);
+			gc.setFont(control.getFont());
+		}
+
+		return gc.textExtent(text, drawFlags);
+	}
+
+	public void dispose() {
+		if (gc != null) {
+			gc.dispose();
+			gc = null;
+		}
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ScaleRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ScaleRenderer.java
@@ -17,10 +17,13 @@ import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.widgets.Scale.*;
 
-class ScaleRenderer implements IScaleRenderer {
-	private static final Color IDLE_COLOR = new Color(Display.getDefault(), 0, 95, 184);
-	private static final Color HOVER_COLOR = new Color(Display.getDefault(), 0, 0, 0);
-	private static final Color DRAG_COLOR = new Color(Display.getDefault(), 204, 204, 204);
+public class ScaleRenderer implements IScaleRenderer {
+
+	public static final String KEY_HANDLE_IDLE = "scale.handle.background"; //$NON-NLS-1$
+	public static final String KEY_HANDLE_HOVER = "scale.handle.background.hover"; //$NON-NLS-1$
+	public static final String KEY_HANDLE_DRAG = "scale.handle.background.drag"; //$NON-NLS-1$
+	public static final String KEY_HANDLE_OUTLINE = "scale.handle.outline"; //$NON-NLS-1$
+	public static final String KEY_NOTCH = "scale.notch.foreground"; //$NON-NLS-1$
 
 	private static Color background;
 
@@ -110,11 +113,13 @@ class ScaleRenderer implements IScaleRenderer {
 		}
 
 		gc.fillRectangle(bar);
-		gc.setForeground(scale.getDisplay().getSystemColor(SWT.COLOR_WIDGET_NORMAL_SHADOW));
+
+		final IColorProvider colorProvider = scale.getColorProvider();
+		gc.setForeground(colorProvider.getColor(KEY_HANDLE_OUTLINE));
 		gc.drawRectangle(bar);
 
 		// prepare for line drawing
-		gc.setForeground(scale.getDisplay().getSystemColor(SWT.COLOR_WIDGET_NORMAL_SHADOW));
+		gc.setForeground(colorProvider.getColor(KEY_NOTCH));
 		gc.setLineWidth(1);
 		gc.setLineWidth(1);
 
@@ -146,12 +151,13 @@ class ScaleRenderer implements IScaleRenderer {
 	}
 
 	private void drawHandle(GC gc, int value) {
+		final IColorProvider colorProvider = scale.getColorProvider();
 		// draw handle
-		Color handleColor = switch (scale.getHandleState()) {
-		case IDLE -> IDLE_COLOR;
-		case HOVER -> HOVER_COLOR;
-		case DRAG -> DRAG_COLOR;
-		};
+		Color handleColor = colorProvider.getColor(switch (scale.getHandleState()) {
+		case IDLE -> KEY_HANDLE_IDLE;
+		case HOVER -> KEY_HANDLE_HOVER;
+		case DRAG -> KEY_HANDLE_DRAG;
+		});
 		gc.setBackground(handleColor);
 		handleBounds = calculateHandleBounds(value);
 		gc.fillRectangle(handleBounds);

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/GC.java
@@ -102,6 +102,9 @@ public class GC extends Resource {
 	static final float[] LINE_DASHDOT_ZERO = new float[]{9, 6, 3, 6};
 	static final float[] LINE_DASHDOTDOT_ZERO = new float[]{9, 3, 3, 3, 3, 3};
 
+	private int xOffset;
+	private int yOffset;
+
 /**
  * Prevents uninitialized instances from being created outside the package.
  */
@@ -322,7 +325,7 @@ public void drawArc (int x, int y, int width, int height, int startAngle, int ar
  * @see #drawRectangle(int, int, int, int)
  */
 public void drawFocus (int x, int y, int width, int height) {
-	innerGC.drawFocus(x, y, width, height);
+	innerGC.drawFocus(x + xOffset, y + yOffset, width, height);
 }
 
 
@@ -431,7 +434,7 @@ public void drawLine (int x1, int y1, int x2, int y2) {
  */
 public void drawOval (int x, int y, int width, int height) {
 
-	innerGC.drawOval(x, y, width, height);
+	innerGC.drawOval(x + xOffset, y + yOffset, width, height);
 
 }
 
@@ -542,7 +545,7 @@ public void drawPolyline (int[] pointArray) {
  * </ul>
  */
 public void drawRectangle (int x, int y, int width, int height) {
-	innerGC.drawRectangle(x, y, width, height);
+	innerGC.drawRectangle(x + xOffset, y + yOffset, width, height);
 }
 
 /**
@@ -587,7 +590,7 @@ public void drawRectangle (Rectangle rect) {
  * </ul>
  */
 public void drawRoundRectangle (int x, int y, int width, int height, int arcWidth, int arcHeight) {
-	innerGC.drawRoundRectangle(x, y, width, height, arcWidth, arcHeight);
+	innerGC.drawRoundRectangle(x + xOffset, y + yOffset, width, height, arcWidth, arcHeight);
 }
 
 
@@ -742,7 +745,7 @@ public void drawText (String string, int x, int y, boolean isTransparent) {
  * </ul>
  */
 public void drawText (String string, int x, int y, int flags) {
-	innerGC.drawText(string, x, y, flags);
+	innerGC.drawText(string, x + xOffset, y + yOffset, flags);
 }
 
 /**
@@ -837,7 +840,7 @@ public void fillGradientRectangle (int x, int y, int width, int height, boolean 
  * @see #drawOval
  */
 public void fillOval (int x, int y, int width, int height) {
-	innerGC.fillOval(x, y, width, height);
+	innerGC.fillOval(x + xOffset, y + yOffset, width, height);
 }
 
 /**
@@ -946,7 +949,7 @@ public void fillRectangle (Rectangle rect) {
  * @see #drawRoundRectangle
  */
 public void fillRoundRectangle (int x, int y, int width, int height, int arcWidth, int arcHeight) {
-	innerGC.fillRoundRectangle(x, y, width, height, arcWidth, arcHeight);
+	innerGC.fillRoundRectangle(x + xOffset, y + yOffset, width, height, arcWidth, arcHeight);
 }
 
 
@@ -1640,7 +1643,7 @@ public void setBackgroundPattern (Pattern pattern) {
  * </ul>
  */
 public void setClipping (int x, int y, int width, int height) {
-	innerGC.setClipping(x, y, width, height);
+	innerGC.setClipping(x + xOffset, y + yOffset, width, height);
 }
 
 /**
@@ -2183,4 +2186,8 @@ public void commit() {
 
 }
 
+	public void transform(int x, int y) {
+		xOffset += x;
+		yOffset += y;
+	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -6149,5 +6149,12 @@ private static void resizeFont(Control control, int newZoom) {
 		control.setFont(Font.win32_new(font, newZoom));
 	}
 }
+
+/**
+ * Returns the color provider of the associated display.
+ */
+public IColorProvider getColorProvider() {
+	return getDisplay().getColorProvider();
+}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/DefaultColorProvider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/DefaultColorProvider.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Syntevo GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Thomas Singer (Syntevo) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.widgets;
+
+import java.util.*;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+
+public class DefaultColorProvider implements IColorProvider {
+	private final Map<String, Color> map = new HashMap<>();
+	protected final Display display;
+
+	public DefaultColorProvider(Display display) {
+		this.display = Objects.requireNonNull(display);
+
+		final Color selection = new Color(0, 95, 184);
+		final Color disabled = new Color(128, 128, 128);
+
+		map.put(Label.KEY_DISABLED, disabled);
+		map.put(Label.KEY_SHADOW_IN_LIGHT, new Color(255, 255, 255));
+		map.put(Label.KEY_SHADOW_IN_DARK, new Color(160, 160, 160));
+		map.put(Label.KEY_SHADOW_OUT_LIGHT, new Color(227, 227, 227));
+		map.put(Label.KEY_SHADOW_OUT_DARK, new Color(160, 160, 160));
+
+		map.put(Button.KEY_BUTTON, new Color(255, 255, 255));
+		map.put(Button.KEY_HOVER, new Color(224, 238, 254));
+		map.put(Button.KEY_TOGGLE, new Color(204, 228, 247));
+		map.put(Button.KEY_SELECTION, selection);
+		map.put(Button.KEY_TRISTATE, new Color(128, 128, 128));
+		map.put(Button.KEY_OUTLINE, new Color(160, 160, 160));
+		map.put(Button.KEY_TEXT, new Color(0, 0, 0));
+		map.put(Button.KEY_DISABLE, disabled);
+		map.put(Button.KEY_ARROW, new Color(128, 128, 128));
+
+		map.put(ScaleRenderer.KEY_HANDLE_IDLE, selection);
+		map.put(ScaleRenderer.KEY_HANDLE_HOVER, new Color(0, 0, 0));
+		map.put(ScaleRenderer.KEY_HANDLE_DRAG, new Color(204, 204, 204));
+		map.put(ScaleRenderer.KEY_HANDLE_OUTLINE, new Color(160, 160, 160));
+		map.put(ScaleRenderer.KEY_NOTCH, new Color(160, 160, 160));
+	}
+
+	@Override
+	public Color getColor(String key) {
+		final Color color = map.get(Objects.requireNonNull(key));
+		if (color == null) {
+			SWT.error(SWT.ERROR_UNSPECIFIED);
+		}
+		return color;
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/DefaultColorProvider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/DefaultColorProvider.java
@@ -34,15 +34,15 @@ public class DefaultColorProvider implements IColorProvider {
 		map.put(Label.KEY_SHADOW_OUT_LIGHT, new Color(227, 227, 227));
 		map.put(Label.KEY_SHADOW_OUT_DARK, new Color(160, 160, 160));
 
-		map.put(Button.KEY_BUTTON, new Color(255, 255, 255));
-		map.put(Button.KEY_HOVER, new Color(224, 238, 254));
-		map.put(Button.KEY_TOGGLE, new Color(204, 228, 247));
-		map.put(Button.KEY_SELECTION, selection);
-		map.put(Button.KEY_TRISTATE, new Color(128, 128, 128));
-		map.put(Button.KEY_OUTLINE, new Color(160, 160, 160));
-		map.put(Button.KEY_TEXT, new Color(0, 0, 0));
-		map.put(Button.KEY_DISABLE, disabled);
-		map.put(Button.KEY_ARROW, new Color(128, 128, 128));
+		map.put(LWAbstractButtonUI.KEY_BUTTON, new Color(255, 255, 255));
+		map.put(LWAbstractButtonUI.KEY_HOVER, new Color(224, 238, 254));
+		map.put(LWAbstractButtonUI.KEY_TOGGLE, new Color(204, 228, 247));
+		map.put(LWAbstractButtonUI.KEY_SELECTION, selection);
+		map.put(LWAbstractButtonUI.KEY_TRISTATE, new Color(128, 128, 128));
+		map.put(LWAbstractButtonUI.KEY_OUTLINE, new Color(160, 160, 160));
+		map.put(LWAbstractButtonUI.KEY_TEXT, new Color(0, 0, 0));
+		map.put(LWAbstractButtonUI.KEY_DISABLE, disabled);
+		map.put(LWAbstractButtonUI.KEY_ARROW, new Color(128, 128, 128));
 
 		map.put(ScaleRenderer.KEY_HANDLE_IDLE, selection);
 		map.put(ScaleRenderer.KEY_HANDLE_HOVER, new Color(0, 0, 0));

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -556,6 +556,7 @@ public class Display extends Device implements Executor {
 		CommonWidgetsDPIChangeHandlers.registerCommonHandlers();
 	}
 
+	private IColorProvider colorProvider;
 
 /*
 * TEMPORARY CODE.
@@ -594,6 +595,8 @@ public Display () {
  */
 public Display (DeviceData data) {
 	super (data);
+
+	colorProvider = new DefaultColorProvider(this);
 }
 
 Control _getFocusControl () {
@@ -5538,5 +5541,21 @@ private Point getPointFromPixels(Monitor monitor, int x, int y) {
 	int mappedX = DPIUtil.scaleDown(x - monitor.clientX, zoom) + monitor.clientX;
 	int mappedY = DPIUtil.scaleDown(y - monitor.clientY, zoom) + monitor.clientY;
 	return new Point(mappedX, mappedY);
+}
+
+/**
+ * Returns the color provider used for custom-drawn controls.
+ * @return a non-null instance of the color provider
+ */
+public IColorProvider getColorProvider() {
+	return colorProvider;
+}
+
+/**
+ * Sets the color provider used for custom-drawn controls.
+ * @param colorProvider a non-null color provider
+ */
+public void setColorProvider(IColorProvider colorProvider) {
+	this.colorProvider = Objects.requireNonNull(colorProvider);
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/LWAbstractButtonUI.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/LWAbstractButtonUI.java
@@ -1,0 +1,16 @@
+package org.eclipse.swt.widgets;
+
+/**
+ * @author Thomas Singer
+ */
+public class LWAbstractButtonUI {
+	public static final String KEY_BUTTON = "button.background"; //$NON-NLS-1$
+	public static final String KEY_TEXT = "button.text"; //$NON-NLS-1$
+	public static final String KEY_DISABLE = "button.disable"; //$NON-NLS-1$
+	public static final String KEY_SELECTION = "button.background.selection"; //$NON-NLS-1$
+	public static final String KEY_HOVER = "button.background.hover"; //$NON-NLS-1$
+	public static final String KEY_TOGGLE = "button.background.toggle"; //$NON-NLS-1$
+	public static final String KEY_ARROW = "button.arrow"; //$NON-NLS-1$
+	public static final String KEY_OUTLINE = "button.outline"; //$NON-NLS-1$
+	public static final String KEY_TRISTATE = "button.tristate"; //$NON-NLS-1$
+}

--- a/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/leightweight/LWTest.java
+++ b/examples/org.eclipse.swt.examples/src/org/eclipse/swt/examples/leightweight/LWTest.java
@@ -1,0 +1,56 @@
+package org.eclipse.swt.examples.leightweight;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.widgets.*;
+
+/**
+ * @author Thomas Singer
+ */
+public class LWTest {
+	public static void main(String[] args) {
+		final Display display = new Display();
+
+		final Shell shell = new Shell(display, SWT.SHELL_TRIM | SWT.NO_BACKGROUND);
+		final LWBridge bridge = new LWBridge(shell);
+		final LWContainer container = bridge.getContainer();
+//		container.setLayoutManager(new LWRowLayout());
+		container.setLayoutManager(new LWColumnLayout(LWColumnLayout.Alignment.BEGIN)
+				                           .setMargin(10, 5)
+				                           .setSpacing(10));
+		final LWRadioButton.DefaultGroup group = new LWRadioButton.DefaultGroup();
+		final LWRadioButton radioButton1 = new LWRadioButton("Hello", group, container);
+		logSelection(radioButton1);
+		final LWRadioButton radioButton2 = new LWRadioButton("World!!!!", group, container);
+		logSelection(radioButton2);
+		final LWRadioButton radioButton3 = new LWRadioButton("SWT rocks", group, container);
+		radioButton3.setSelected();
+		logSelection(radioButton3);
+
+		final LWButton addButton = new LWButton("Add", container);
+		addButton.setLayoutData(LWColumnLayout.Alignment.FILL);
+		addButton.addListener(type -> {
+					if (type == LWAbstractButton.EVENT_SELECTED) {
+						System.out.println("Add selected");
+					}
+				});
+		bridge.layout();
+
+		shell.setSize(400, 300);
+		shell.open();
+
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch()) {
+				display.sleep();
+			}
+		}
+		display.dispose();
+	}
+
+	private static void logSelection(LWRadioButton radioButton) {
+		radioButton.addListener(type -> {
+			if (type == LWAbstractButton.EVENT_SELECTED && radioButton.isSelected()) {
+				System.out.println(radioButton.getText() + " selected");
+			}
+		});
+	}
+}


### PR DESCRIPTION
Please have a look at this proof of concept approach. The test you can find at `LWTest` will create a `Shell` and all controls inside are light-weight controls. The existing heavy-weight, but owner drawn controls use the light-weight controls, but the light-weight controls also can be used inside light-weight containers, so all except the root shell is light-weight.

The code is far from perfect, but should be some kind of discussion base line.