### PR TITLE
Add missing GC#commit() call to Label#onPaint()

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
@@ -744,6 +744,7 @@ public class Label extends Control implements ICustomWidget {
 			}
 		}
 
+		gc.commit();
 		gc.dispose();
 	}
 


### PR DESCRIPTION
The GC#commit() call in Label#onPaint() was removed when adding auto-commit logic to the SkijaGC. It has not been re-added when reverting the auto-commit logic for SkijaGC, resulting in not properly drawn Label. This readds the according commit() call.