### PR TITLE
Execute paint operations on every paint event in Skija snippets #80

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaCanvasTest.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaCanvasTest.java
@@ -1,6 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2024 SAP SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package org.eclipse.swt.snippets;
 
-import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.widgets.*;
 
@@ -16,18 +25,14 @@ public class SkijaCanvasTest {
 
 		shell.setVisible(true);
 
+		shell.addPaintListener(event -> {
+			SkijaGC skijaGC = new SkijaGC((NativeGC) event.gc.innerGC, null);
 
-		SkijaGC skijaGC = new SkijaGC(shell, SWT.NONE);
+			skijaGC.drawText("Hello World Test", 0, 0);
+			skijaGC.drawLine(0, 0, 200, 200);
 
-
-		skijaGC.drawText("Hello World Test", 0, 0);
-
-
-		skijaGC.drawLine(0, 0,  200 , 200);
-
-
-		skijaGC.commit();
-
+			skijaGC.commit();
+		});
 
 		shell.open();
 		while (!shell.isDisposed()) {
@@ -35,7 +40,6 @@ public class SkijaCanvasTest {
 				display.sleep();
 		}
 		display.dispose();
-
 
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaDrawImage.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaDrawImage.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2024 SAP SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package org.eclipse.swt.snippets;
 
 import org.eclipse.swt.*;
@@ -21,15 +31,14 @@ public class SkijaDrawImage {
 		gc.fillRectangle (image.getBounds ());
 		gc.dispose ();
 
+		shell.addPaintListener(event -> {
+			SkijaGC skijaGC = new SkijaGC((NativeGC) event.gc.innerGC, null);
 
+			skijaGC.drawImage(image, 0, 0);
+			skijaGC.drawText("Test", 0, 0);
 
-
-		SkijaGC skijaGC = new SkijaGC(shell, SWT.NONE);
-
-		skijaGC.drawImage(image, 0, 0);
-		skijaGC.drawText("Test", 0, 0);
-
-		skijaGC.commit();
+			skijaGC.commit();
+		});
 
 
 		shell.open();


### PR DESCRIPTION
Currently, painting in the SkijaCanvasTest and SkijaDrawImage only happen once, such that on subsequent paint events the canvas is cleared. This change corrects the snippets to repaint on every paint event.

Fixes https://github.com/swt-initiative31/prototype-skija/issues/80

@DenisUngemach Copyright headers are missing in the changed classes. They were introduced by you, so can you please approve that we can add them?