### PR TITLE
Text Widget: Application crashes on Backspace #79

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/CSimpleText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/CSimpleText.java
@@ -303,7 +303,7 @@ public class CSimpleText extends Scrollable implements ICustomWidget {
 				model.removeCharacterBeforeCaret();
 				break;
 			case SWT.DEL:
-				model.removeCharacterBeforeCaret();
+				model.removeCharacterAfterCaret();
 				break;
 			default:
 				if (e.keyCode == 0 || e.character != '\0') {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/CSimpleTextModel.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/CSimpleTextModel.java
@@ -60,7 +60,7 @@ public class CSimpleTextModel {
 	void removeCharacterBeforeCaret() {
 		if (isTextSelected()) {
 			replaceSelectedTextWith("");
-		} else {
+		} else if (getCaretOffset() > 0) {
 			replaceWith("", getCaretOffset() - 1, getCaretOffset());
 		}
 	}
@@ -68,7 +68,7 @@ public class CSimpleTextModel {
 	void removeCharacterAfterCaret() {
 		if (isTextSelected()) {
 			replaceSelectedTextWith("");
-		} else {
+		} else if (getCaretOffset() < text.length()) {
 			replaceWith("", getCaretOffset(), getCaretOffset() + 1);
 		}
 	}


### PR DESCRIPTION
Fixed boundary check failures for cursor positions and fixed "delete char" behavior since it was actually doing a "backspace"