### PR TITLE
Simplify font style calculation in TextLayout

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -18,8 +18,10 @@ import java.util.function.*;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.internal.*;
+import org.eclipse.swt.widgets.*;
 
 import io.github.humbleui.skija.*;
+import io.github.humbleui.skija.Canvas;
 import io.github.humbleui.skija.Font;
 import io.github.humbleui.types.*;
 
@@ -761,6 +763,11 @@ public class SkijaGC extends GCHandle {
 		if (font == null)
 			font = innerGC.getFont();
 
+		this.font = convertToSkijaFont(font);
+		this.baseSymbolHeight = this.font.measureText("T").getHeight();
+	}
+
+	static Font convertToSkijaFont(org.eclipse.swt.graphics.Font font) {
 		FontData fontData = font.getFontData()[0];
 		FontStyle style = FontStyle.NORMAL;
 		boolean isBold = (fontData.getStyle() & SWT.BOLD) != 0;
@@ -772,15 +779,16 @@ public class SkijaGC extends GCHandle {
 		} else if (isItalic) {
 			style = FontStyle.ITALIC;
 		}
-		this.font = new Font(Typeface.makeFromName(fontData.getName(), style));
+		Font skijaFont = new Font(Typeface.makeFromName(fontData.getName(), style));
 		int fontSize = DPIUtil.scaleUp(fontData.getHeight(), DPIUtil.getNativeDeviceZoom());
 		if (SWT.getPlatform().equals("win32")) {
-			fontSize *= this.font.getSize() / innerGC.getDevice().getSystemFont().getFontData()[0].getHeight();
+			fontSize *= skijaFont.getSize() / Display.getDefault().getSystemFont().getFontData()[0].getHeight();
 		}
-		this.font.setSize(fontSize);
-		this.font.setEdging(FontEdging.SUBPIXEL_ANTI_ALIAS);
-		this.font.setSubpixel(true);
-		this.baseSymbolHeight = this.font.measureText("T").getHeight();
+		skijaFont.setSize(fontSize);
+		skijaFont.setEdging(FontEdging.SUBPIXEL_ANTI_ALIAS);
+		skijaFont.setSubpixel(true);
+
+		return skijaFont;
 	}
 
 	@Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/graphics/TextLayout.java
@@ -877,16 +877,16 @@ public final class TextLayout extends Resource {
 		if (f == null)
 			f = device.getSystemFont();
 
-		FontData fd = f.getFontData()[0];
+		String fontFamily = f.getFontData()[0].getName();
 
 		io.github.humbleui.skija.paragraph.TextStyle normal = new io.github.humbleui.skija.paragraph.TextStyle()
 				.setFontSize(getFontSize())
-				.setFontFamilies(new String[]{fd.getName()})
+				.setFontFamilies(new String[] { fontFamily })
 				.setColor(0xFF000000);
 
 		io.github.humbleui.skija.paragraph.TextStyle selectionStyle = new io.github.humbleui.skija.paragraph.TextStyle()
 				.setFontSize(getFontSize())
-				.setFontFamilies(new String[]{fd.getName()})
+				.setFontFamilies(new String[] { fontFamily })
 				.setForeground(new Paint().setColor(SkijaGC
 						.convertSWTColorToSkijaColor(selectionForeground)))
 				.setBackground(new Paint().setColor(SkijaGC
@@ -936,7 +936,7 @@ public final class TextLayout extends Resource {
 				if (s != "") {
 					if (hasSelection) {
 
-						var ts = convertToTextStyle(si, fd);
+						var ts = convertToTextStyle(si, fontFamily);
 
 						for (int i = si.start; i < nextStyleStart; i++) {
 
@@ -983,7 +983,7 @@ public final class TextLayout extends Resource {
 
 					} else {
 
-						var ts = convertToTextStyle(si, fd);
+						var ts = convertToTextStyle(si, fontFamily);
 						paragraphBuilder.pushStyle(ts);
 
 						addText(paragraphBuilder, tabPlaceholder, s);
@@ -1038,7 +1038,7 @@ public final class TextLayout extends Resource {
 	}
 
 	private io.github.humbleui.skija.paragraph.TextStyle convertToTextStyle(
-			StyleItem si, FontData fd) {
+			StyleItem si, String fontFamily) {
 
 		TextStyle ts = si.style;
 
@@ -1054,7 +1054,7 @@ public final class TextLayout extends Resource {
 
 			return new io.github.humbleui.skija.paragraph.TextStyle()
 					.setFontSize(getFontSize())
-					.setFontFamilies(new String[]{fd.getName()})
+					.setFontFamilies(new String[] { fontFamily })
 					.setForeground(foreP);
 
 		}
@@ -1073,36 +1073,14 @@ public final class TextLayout extends Resource {
 
 		}
 
-		FontStyle fs = FontStyle.NORMAL;
-
 		float fontSize = getFontSize();
+
+		FontStyle fs = FontStyle.NORMAL;
 		if (ts.font != null && ts.font.getFontData() != null
 				&& ts.font.getFontData().length >= 1) {
-			fd = ts.font.getFontData()[0];
-			// fontSize = (float) ((fd.getHeightF() * 1.4) + 2);
-
-			fs = ((fd.getStyle() & SWT.NORMAL) != 0) ? FontStyle.NORMAL : null;
-
-			if (fs == null) {
-				fs = (fd.getStyle() & SWT.BOLD) != 0 ? FontStyle.BOLD : null;
+			try (var skijaFont = SkijaGC.convertToSkijaFont(ts.font)) {
+				fs = skijaFont.getTypeface().getFontStyle();
 			}
-
-			if ((fd.getStyle() & SWT.ITALIC) != 0) {
-
-				if (fs == null) {
-					fs = FontStyle.ITALIC;
-
-				}
-
-				if (fs == FontStyle.BOLD) {
-					fs = FontStyle.BOLD_ITALIC;
-				}
-
-			}
-
-			if (fs == null)
-				fs = FontStyle.NORMAL;
-
 		}
 
 		// boolean underline = ts.underline;
@@ -1122,7 +1100,7 @@ public final class TextLayout extends Resource {
 
 		io.github.humbleui.skija.paragraph.TextStyle textSty = new io.github.humbleui.skija.paragraph.TextStyle()
 				.setFontStyle(fs).setFontSize(fontSize)
-				.setFontFamilies(new String[]{fd.getName()})
+				.setFontFamilies(new String[] { fontFamily })
 				.setForeground(foreP) //
 				.setBackground(backP);
 


### PR DESCRIPTION
The font style calculation in TextLayout is almost equal to the one already existing in SkijaGC. This adapts the TextLayout implementation to reuse the existing functionality.