### PR TITLE
Use the caret display to do timed executions

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/CTextCaret.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/CTextCaret.java
@@ -57,7 +57,7 @@ public class CTextCaret extends Widget {
 				if (currentCaret.blinkCaret()) {
 					int blinkRate = currentCaret.blinkRate;
 					if (blinkRate != 0) {
-						Display.getDefault().timerExec(blinkRate, this);
+						currentCaret.display.timerExec(blinkRate, this);
 					}
 				} else {
 					currentCaret = null;


### PR DESCRIPTION
Avoids an illegal thread access when launching Snippet108 from the SnippetExplorer