### PR TITLE
Initial custom Group widget implementation

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Group_old.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Group_old.java
@@ -42,7 +42,7 @@ import org.eclipse.swt.internal.cocoa.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  * @noextend This class is not intended to be subclassed by clients.
  */
-public class Group extends Composite {
+public class Group_old extends Composite {
 	NSView contentView;
 	String text = "";
 	boolean ignoreResize;
@@ -80,7 +80,7 @@ public class Group extends Composite {
  * @see Widget#checkSubclass
  * @see Widget#getStyle
  */
-public Group (Composite parent, int style) {
+public Group_old (Composite parent, int style) {
 	super (parent, checkStyle (style));
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Group.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Group.java
@@ -1,0 +1,346 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Latha Patil (ETAS GmbH) - Custom draw Group widget using SkijaGC
+ *******************************************************************************/
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.internal.*;
+
+/**
+ * Instances of this class provide an etched border with an optional title.
+ * <p>
+ * Shadow styles are hints and may not be honoured by the platform. To create a
+ * group with the default shadow style for the platform, do not specify a shadow
+ * style.
+ * <dl>
+ * <dt><b>Styles:</b></dt>
+ * <dd>SHADOW_ETCHED_IN, SHADOW_ETCHED_OUT, SHADOW_IN, SHADOW_OUT,
+ * SHADOW_NONE</dd>
+ * <dt><b>Events:</b></dt>
+ * <dd>(none)</dd>
+ * </dl>
+ * <p>
+ * Note: Only one of the above styles may be specified.
+ * </p>
+ * <p>
+ * IMPORTANT: This class is <em>not</em> intended to be subclassed.
+ * </p>
+ *
+ * @see <a href="http://www.eclipse.org/swt/examples.php">SWT Example:
+ *      ControlExample</a>
+ * @see <a href="http://www.eclipse.org/swt/">Sample code and further
+ *      information</a>
+ * @noextend This class is not intended to be subclassed by clients.
+ */
+public class Group extends Composite {
+	private String text = "";
+	private static final int CLIENT_INSET = 3;
+	private final int orientation;
+	private static final int DRAW_FLAGS = SWT.DRAW_MNEMONIC | SWT.DRAW_TAB | SWT.DRAW_TRANSPARENT | SWT.DRAW_DELIMITER;
+	private Point textExtentCache;
+
+	/**
+	 * Constructs a new instance of this class given its parent and a style value
+	 * describing its behavior and appearance.
+	 * <p>
+	 * The style value is either one of the style constants defined in class
+	 * <code>SWT</code> which is applicable to instances of this class, or must be
+	 * built by <em>bitwise OR</em>'ing together (that is, using the
+	 * <code>int</code> "|" operator) two or more of those <code>SWT</code> style
+	 * constants. The class description lists the style constants that are
+	 * applicable to the class. Style bits are also inherited from superclasses.
+	 * </p>
+	 *
+	 * @param parent a composite control which will be the parent of the new
+	 *               instance (cannot be null)
+	 * @param style  the style of control to construct
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_NULL_ARGUMENT - if the parent
+	 *                                     is null</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     parent</li>
+	 *                                     <li>ERROR_INVALID_SUBCLASS - if this
+	 *                                     class is not an allowed subclass</li>
+	 *                                     </ul>
+	 *
+	 * @see SWT#SHADOW_ETCHED_IN
+	 * @see SWT#SHADOW_ETCHED_OUT
+	 * @see SWT#SHADOW_IN
+	 * @see SWT#SHADOW_OUT
+	 * @see SWT#SHADOW_NONE
+	 * @see Widget#checkSubclass
+	 * @see Widget#getStyle
+	 */
+	public Group(Composite parent, int style) {
+		super(parent, checkStyle(style));
+		Listener listener = event -> {
+			switch (event.type) {
+			case SWT.Paint -> onPaint(event);
+			case SWT.Resize -> redraw();
+			}
+		};
+		addListener(SWT.Paint, listener);
+		addListener(SWT.Resize, listener);
+		orientation = style & (SWT.LEFT_TO_RIGHT | SWT.RIGHT_TO_LEFT);
+	}
+
+	private void onPaint(Event event) {
+		Drawing.drawWithGC(this, event.gc, this::drawGroup);
+	}
+
+	private void drawGroup(GC gc) {
+		Point size = getSize();
+		int width = size.x;
+		int height = size.y;
+		if (textExtentCache == null) {
+			textExtentCache = calculateTextExtent();
+		}
+		int titleWidth = textExtentCache.x;
+		int titleHeight = textExtentCache.y;
+
+		int inset = 2;
+		int groupInset = 8;
+		int borderRadius = 6;
+		int textX = inset + groupInset;
+		int textY = titleHeight;
+		int groupWidth = width - (inset * 2);
+		int groupHeight = height - (inset * 8);
+		if (isBorderSet()) {
+			// Border has to be drawn using Skija once native border is disabled.
+			inset = (orientation == SWT.RIGHT_TO_LEFT) ? groupInset / 2 : 0;
+			groupWidth -= 1;
+			groupHeight -= groupInset / 4;
+		}
+		// Set shadow color
+		gc.setForeground(getShadowColor());
+		// Draw group border
+		gc.drawRoundRectangle(inset, (textY / 2), groupWidth, groupHeight, borderRadius, borderRadius);
+		// Draw text background (A fillRectangle to erase the part of the group border
+		// where text is drawn) and text
+		int textPosX = (orientation == SWT.RIGHT_TO_LEFT) ? groupWidth - groupInset - titleWidth : textX;
+		gc.fillRectangle(textPosX, (textY / 2), titleWidth, gc.getLineWidth() + 1);
+		gc.setForeground(getForeground());
+		gc.drawText(text, textPosX, 0, DRAW_FLAGS);
+	}
+
+	private Point calculateTextExtent() {
+		return Drawing.getTextExtent(this, text, DRAW_FLAGS);
+	}
+
+	private Color getShadowColor() {
+		if ((style & SWT.SHADOW_ETCHED_IN) != 0) {
+			return new Color(136, 136, 136);
+		}
+		if ((style & SWT.SHADOW_ETCHED_OUT) != 0) {
+			return new Color(68, 68, 68);
+		}
+		if ((style & SWT.SHADOW_IN) != 0) {
+			return new Color(102, 102, 102);
+		}
+		if ((style & SWT.SHADOW_OUT) != 0) {
+			return new Color(187, 187, 187);
+		}
+		return getForeground();
+	}
+
+	static int checkStyle(int style) {
+		style |= SWT.NO_FOCUS;
+		if ((style & SWT.LEFT_TO_RIGHT) != 0) {
+			style &= ~SWT.RIGHT_TO_LEFT;
+		} else if ((style & SWT.RIGHT_TO_LEFT) != 0) {
+			style &= ~SWT.LEFT_TO_RIGHT;
+		} else {
+			style |= SWT.LEFT_TO_RIGHT;
+			style &= ~SWT.RIGHT_TO_LEFT;
+		}
+		if ((style & SWT.BORDER) != 0) {
+			style |= SWT.SHADOW_IN;
+		}
+		/*
+		 * Even though it is legal to create this widget with scroll bars, they serve no
+		 * useful purpose because they do not automatically scroll the widget's client
+		 * area. The fix is to clear the SWT style.
+		 */
+		return style & ~(SWT.H_SCROLL | SWT.V_SCROLL);
+	}
+
+	private boolean isBorderSet() {
+		return (style & SWT.BORDER) != 0;
+	}
+
+	@Override
+	protected void checkSubclass() {
+		if (!isValidSubclass()) {
+			error(SWT.ERROR_INVALID_SUBCLASS);
+		}
+	}
+
+	@Override
+	public Point computeSize(int wHint, int hHint, boolean changed) {
+		checkWidget();
+		Point size = super.computeSize(wHint, hHint, changed);
+		if (!changed && size.x == wHint && size.y == hHint) {
+			return size;
+		}
+		if (text == null || text.isEmpty()) {
+			return size;
+		}
+		Layout layout = getLayout();
+		Point layoutSize = (layout != null) ? DPIUtil.autoScaleDown(size) : computeChildrenSize(changed);
+
+		if (textExtentCache == null) {
+			textExtentCache = calculateTextExtent();
+		}
+
+		int width = Math.max(10, Math.max(layoutSize.x, textExtentCache.x + CLIENT_INSET * 6));
+		int height = Math.max(10, Math.max(layoutSize.y - (CLIENT_INSET * 4), textExtentCache.y + CLIENT_INSET * 4));
+
+		return new Point(wHint != SWT.DEFAULT ? wHint : width, hHint != SWT.DEFAULT ? hHint : height);
+	}
+
+	private Point computeChildrenSize(boolean changed) {
+		Point size = new Point(0, 0);
+		for (Control child : getChildren()) {
+			Point childSize = child.computeSize(SWT.DEFAULT, SWT.DEFAULT, changed);
+			size.x = Math.max(size.x, childSize.x);
+			size.y += childSize.y; // Stack vertically
+		}
+		return size;
+	}
+
+	@Override
+	public Rectangle computeTrim(int x, int y, int width, int height) {
+		checkWidget();
+		Rectangle trim = super.computeTrim(x, y, width, height);
+		if (textExtentCache == null) {
+			textExtentCache = calculateTextExtent();
+		}
+		trim.width = width + CLIENT_INSET * 2;
+		trim.height = height + CLIENT_INSET * 2;
+		trim.height += textExtentCache.y + CLIENT_INSET * 2;
+		return DPIUtil.autoScaleUp(trim);
+	}
+
+	@Override
+	public void setEnabled(boolean enabled) {
+		if (enabled == getEnabled()) {
+			return;
+		}
+		super.setEnabled(enabled);
+		if (parent != null && parent.isEnabled()) {
+			redraw();
+		}
+	}
+
+	@Override
+	public Rectangle getClientArea() {
+		checkWidget();
+		Rectangle rect = super.getClientArea();
+		if (rect.isEmpty()) {
+			return rect;
+		}
+		int y = 10;
+		if (text != null && !text.isEmpty()) {
+			if (textExtentCache == null) {
+				textExtentCache = calculateTextExtent();
+			}
+			y = textExtentCache.y - 5;
+		}
+		return new Rectangle(rect.x + CLIENT_INSET, y, Math.max(0, rect.width - CLIENT_INSET * 2),
+				Math.max(0, rect.height - CLIENT_INSET * 8));
+	}
+
+	@Override
+	String getNameText() {
+		return getText();
+	}
+
+	/**
+	 * Returns the receiver's text, which is the string that the is used as the
+	 * <em>title</em>. If the text has not previously been set, returns an empty
+	 * string.
+	 *
+	 * @return the text
+	 *
+	 * @exception SWTException
+	 *                         <ul>
+	 *                         <li>ERROR_WIDGET_DISPOSED - if the receiver has been
+	 *                         disposed</li>
+	 *                         <li>ERROR_THREAD_INVALID_ACCESS - if not called from
+	 *                         the thread that created the receiver</li>
+	 *                         </ul>
+	 */
+	public String getText() {
+		return text;
+	}
+
+	@Override
+	public void setFont(Font font) {
+		checkWidget();
+		super.setFont(font);
+		textExtentCache = null;
+	}
+
+	/**
+	 * Sets the receiver's text, which is the string that will be displayed as the
+	 * receiver's <em>title</em>, to the argument, which may not be null. The string
+	 * may include the mnemonic character.
+	 * <p>
+	 * Mnemonics are indicated by an '&amp;' that causes the next character to be
+	 * the mnemonic. When the user presses a key sequence that matches the mnemonic,
+	 * focus is assigned to the first child of the group. On most platforms, the
+	 * mnemonic appears underlined but may be emphasised in a platform specific
+	 * manner. The mnemonic indicator character '&amp;' can be escaped by doubling
+	 * it in the string, causing a single '&amp;' to be displayed.
+	 * </p>
+	 * <p>
+	 * Note: If control characters like '\n', '\t' etc. are used in the string, then
+	 * the behavior is platform dependent.
+	 * </p>
+	 *
+	 * @param text the new text
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_NULL_ARGUMENT - if the text is
+	 *                                     null</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 */
+	public void setText(String text) {
+		checkWidget();
+		if (text == null) {
+			text = ""; //$NON-NLS-1$
+		}
+		if (!text.equals(this.text)) {
+			this.text = text;
+			textExtentCache = null;
+			redraw();
+		}
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Group_old.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Group_old.java
@@ -45,7 +45,7 @@ import org.eclipse.swt.internal.gtk4.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  * @noextend This class is not intended to be subclassed by clients.
  */
-public class Group extends Composite {
+public class Group_old extends Composite {
 	long clientHandle, labelHandle;
 	String text = "";
 	// We use this to keep track of the foreground color
@@ -83,7 +83,7 @@ public class Group extends Composite {
  * @see Widget#checkSubclass
  * @see Widget#getStyle
  */
-public Group (Composite parent, int style) {
+public Group_old (Composite parent, int style) {
 	super (parent, checkStyle (style));
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Group_Old.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Group_Old.java
@@ -43,7 +43,7 @@ import org.eclipse.swt.internal.win32.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  * @noextend This class is not intended to be subclassed by clients.
  */
-public class Group extends Composite {
+public class Group_Old extends Composite {
 	String text = "";
 	static final int CLIENT_INSET = 3;
 	static final long GroupProc;
@@ -101,7 +101,7 @@ public class Group extends Composite {
  * @see Widget#checkSubclass
  * @see Widget#getStyle
  */
-public Group (Composite parent, int style) {
+public Group_Old (Composite parent, int style) {
 	super (parent, checkStyle (style));
 }
 

--- a/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetGroup.java
+++ b/examples/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetGroup.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2025 ETAS GmbH and others, all rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ETAS GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.snippets;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.layout.*;
+import org.eclipse.swt.widgets.*;
+
+public class SnippetGroup {
+    public static void main(String[] args) {
+        Display display = new Display();
+        Shell shell = new Shell(display);
+        shell.setText("SWT Group Widget");
+        shell.setSize(500, 500);
+        shell.setLayout(new GridLayout(1, false));
+
+        Group group1 = new Group(shell, SWT.BORDER);
+        group1.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        group1.setText("Students");
+        group1.setLayout(new GridLayout(1, true));
+        Group group = new Group(group1, SWT.BORDER);
+        group.setText("User Information");
+
+       // group.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
+        group.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        group.setLayout(new GridLayout(2, false));
+
+        Label nameLabel = new Label(group, SWT.NONE);
+        nameLabel.setText("Name of the User:");
+
+        Text nameText = new Text(group, SWT.BORDER);
+        nameText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+
+        Label emailLabel = new Label(group, SWT.NONE);
+        emailLabel.setText("Email:");
+
+        Text emailText = new Text(group, SWT.BORDER);
+        emailText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+
+        Button subscribeCheckbox = new Button(group, SWT.CHECK);
+        subscribeCheckbox.setText("Subscribe to newsletter");
+        subscribeCheckbox.setSelection(true);
+        GridData checkData = new GridData();
+        checkData.horizontalSpan = 2;
+        subscribeCheckbox.setLayoutData(checkData);
+
+        Button submitButton = new Button(group, SWT.PUSH);
+        submitButton.setText("Submit");
+        GridData buttonData = new GridData(SWT.RIGHT, SWT.CENTER, false, false);
+        buttonData.horizontalSpan = 2;
+        submitButton.setLayoutData(buttonData);
+
+        submitButton.addListener(SWT.Selection, event -> {
+            System.out.println("Submitted: " + nameText.getText() + ", " + emailText.getText());
+        });
+
+        shell.open();
+
+        while (!shell.isDisposed()) {
+            if (!display.readAndDispatch()) {
+                display.sleep();
+            }
+        }
+        display.dispose();
+    }
+}
+


### PR DESCRIPTION
Known Issues : 

1. A filled rectangle is drawn to erase the part of the Group where the title is present. This rectangle is slightly visible in the `controlExample` when the background color is white, but it is programmatically treated as grey.
2.  Text Rendering: Text orientation works as expected, but text direction does not behave correctly.
3. HiDPI Scaling:  Unable to test `controlExample` when scaled to 175% because the control example does not fit within the screen.
4. `PrintWidget` not yet worked on.
5. SWT.Border is working - Shadow is not visible . Border has to be drawn using skija once native border is disabled. Not able to disable native border at present.
6. mnemonic operations are removed to resolve compilation errors in Mac and Linux
Any suggestions are welcome.