### PR TITLE
SkijaGC: fix clipping offset

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -27,6 +27,9 @@ import io.github.humbleui.types.*;
 
 public class SkijaGC extends GCHandle {
 	private final Surface surface;
+	private final int offsetX;
+	private final int offsetY;
+
 	private Rectangle clipping;
 
 	private NativeGC innerGC;
@@ -43,6 +46,8 @@ public class SkijaGC extends GCHandle {
 			backgroundColor = extractBackgroundColor(gc);
 		surface = createSurface(backgroundColor);
 		clipping = innerGC.getClipping();
+		offsetX = clipping.x;
+		offsetY = clipping.y;
 		initFont();
 	}
 
@@ -172,7 +177,7 @@ public class SkijaGC extends GCHandle {
 		Rectangle originalArea = innerGC.getClipping();
 		Rectangle scaledArea = DPIUtil.autoScaleUp(originalArea);
 		innerGC.drawImage(transferImage, 0, 0, scaledArea.width, scaledArea.height, //
-				0, 0, originalArea.width, originalArea.height);
+				offsetX, offsetY, originalArea.width, originalArea.height);
 		transferImage.dispose();
 		surface.close();
 	}
@@ -200,7 +205,7 @@ public class SkijaGC extends GCHandle {
 	@Override
 	public void drawImage(Image image, int x, int y) {
 		Canvas canvas = surface.getCanvas();
-		canvas.drawImage(convertSWTImageToSkijaImage(image), DPIUtil.autoScaleUp(x), DPIUtil.autoScaleUp(y));
+		canvas.drawImage(convertSWTImageToSkijaImage(image), DPIUtil.autoScaleUp(x - offsetX), DPIUtil.autoScaleUp(y - offsetY));
 	}
 
 	@Override
@@ -497,7 +502,7 @@ public class SkijaGC extends GCHandle {
 		}
 		performDrawText(paint -> {
 			TextBlob textBlob = buildTextBlob(text);
-			Point point = calculateSymbolCenterPoint(x, y);
+			Point point = calculateSymbolCenterPoint(x - offsetX, y - offsetY);
 			surface.getCanvas().drawTextBlob(textBlob, point.x, point.y, paint);
 		});
 	}
@@ -727,7 +732,7 @@ public class SkijaGC extends GCHandle {
 				xCoord = i;
 				isXCoord = false;
 			} else {
-				ps.add(new io.github.humbleui.types.Point(xCoord, i));
+				ps.add(new io.github.humbleui.types.Point(xCoord - offsetX, i - offsetY));
 				isXCoord = true;
 			}
 		}
@@ -870,8 +875,8 @@ public class SkijaGC extends GCHandle {
 	}
 
 	private Rect createScaledRectangle(int x, int y, int width, int height) {
-		return new Rect(DPIUtil.autoScaleUp(x), DPIUtil.autoScaleUp(y), DPIUtil.autoScaleUp(x + width),
-				DPIUtil.autoScaleUp(y + height));
+		return new Rect(DPIUtil.autoScaleUp(x - offsetX), DPIUtil.autoScaleUp(y - offsetY),
+				DPIUtil.autoScaleUp(x + width - offsetX), DPIUtil.autoScaleUp(y + height - offsetY));
 	}
 
 	private float getScaledOffsetValue() {
@@ -887,8 +892,8 @@ public class SkijaGC extends GCHandle {
 	}
 
 	private RRect createScaledRoundRectangle(int x, int y, int width, int height, float arcWidth, float arcHeight) {
-		return new RRect(DPIUtil.autoScaleUp(x), DPIUtil.autoScaleUp(y), DPIUtil.autoScaleUp(x + width),
-				DPIUtil.autoScaleUp(y + height),
+		return new RRect(DPIUtil.autoScaleUp(x - offsetX), DPIUtil.autoScaleUp(y - offsetY),
+				DPIUtil.autoScaleUp(x + width - offsetX), DPIUtil.autoScaleUp(y + height - offsetY),
 				new float[] { DPIUtil.autoScaleUp(arcWidth), DPIUtil.autoScaleUp(arcHeight) });
 	}
 


### PR DESCRIPTION
If the clipping region did not start at (0, 0), this caused incorrect locations to be used for drawing.