### PR TITLE
Color-Provider to theme custom controls

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Control.java
@@ -5250,4 +5250,7 @@ static double luma (double[] rgbColor) {
 	return 0.2126f * rgbColor[0] + 0.7152f * rgbColor[1] + 0.0722f * rgbColor[2];
 }
 
+protected final ColorProvider getColorProvider() {
+	return display.getColorProvider();
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Display.java
@@ -340,6 +340,7 @@ public class Display extends Device implements Executor {
 	static Display [] Displays = new Display [1];
 
 	/* Skinning support */
+	private ColorProvider colorProvider;
 	private RendererFactory rendererFactory;
 	static final int GROW_SIZE = 1024;
 	Widget [] skinList = new Widget [GROW_SIZE];
@@ -800,6 +801,7 @@ public Display () {
 public Display (DeviceData data) {
 	super (data);
 
+	colorProvider = DefaultColorProvider.createLightInstance();
 	rendererFactory = new DefaultRendererFactory();
 }
 
@@ -6878,5 +6880,25 @@ public RendererFactory getRendererFactory() {
 public void setRendererFactory(RendererFactory rendererFactory) {
 	if (rendererFactory == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	this.rendererFactory = rendererFactory;
+}
+
+/**
+ * Return the color provider used for custom-drawn controls.
+ * @return a non-null instance of the color provider
+ * @noreference this is still experimental API and might be removed
+ */
+public final ColorProvider getColorProvider() {
+	return colorProvider;
+}
+
+/**
+ * Set the color provider used for custom-drawn controls.
+ * @param colorProvider a non-null color provider
+ * @noreference this is still experimental API and might be removed
+ */
+public final void setColorProvider(ColorProvider colorProvider) {
+	if (colorProvider == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	this.colorProvider = colorProvider;
+	// todo: redraw all (custom-drawn) widgets
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/BasicLabelRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/BasicLabelRenderer.java
@@ -19,11 +19,6 @@ import org.eclipse.swt.graphics.*;
 
 class BasicLabelRenderer extends LabelRenderer {
 
-	private static final Color SHADOW_IN_COLOR1 = new Color(160, 160, 160);
-	private static final Color SHADOW_IN_COLOR2 = new Color(255, 255, 255);
-	private static final Color SHADOW_OUT_COLOR1 = new Color(227, 227, 227);
-	private static final Color SHADOW_OUT_COLOR2 = new Color(160, 160, 160);
-
 	private static final int DRAW_FLAGS = SWT.DRAW_MNEMONIC | SWT.DRAW_TAB
 										  | SWT.DRAW_TRANSPARENT | SWT.DRAW_DELIMITER;
 
@@ -265,7 +260,7 @@ class BasicLabelRenderer extends LabelRenderer {
 		}
 
 		if (lines != null) {
-			gc.setForeground(label.isEnabled() ? label.getForeground() : DISABLED_COLOR);
+			gc.setForeground(label.isEnabled() ? label.getForeground() : getColor(COLOR_DISABLED));
 			for (String line : lines) {
 				int lineX = x;
 				if (lines.length > 1) {
@@ -294,12 +289,12 @@ class BasicLabelRenderer extends LabelRenderer {
 
 		int style = label.getStyle();
 		if ((style & SWT.SHADOW_IN) != 0) {
-			c1 = SHADOW_IN_COLOR1;
-			c2 = SHADOW_IN_COLOR2;
+			c1 = getColor(COLOR_SHADOW_IN1);
+			c2 = getColor(COLOR_SHADOW_IN2);
 		}
 		if ((style & SWT.SHADOW_OUT) != 0) {
-			c1 = SHADOW_OUT_COLOR1;
-			c2 = SHADOW_OUT_COLOR2;
+			c1 = getColor(COLOR_SHADOW_OUT1);
+			c2 = getColor(COLOR_SHADOW_OUT2);
 		}
 
 		if (c1 != null && c2 != null) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ButtonRenderer.java
@@ -18,6 +18,15 @@ import org.eclipse.swt.graphics.*;
 
 public abstract class ButtonRenderer extends ControlRenderer {
 
+	static final String COLOR_HOVER = "button.background.hover"; //$NON-NLS-1$
+	static final String COLOR_TOGGLE = "button.background.toggle"; //$NON-NLS-1$
+	static final String COLOR_SELECTION = "button.background.selection"; //$NON-NLS-1$
+	static final String COLOR_OUTLINE = "button.outline"; //$NON-NLS-1$
+	static final String COLOR_OUTLINE_DISABLED = "button.outline.disabled"; //$NON-NLS-1$
+	static final String COLOR_BOX = "button.box"; //$NON-NLS-1$
+	static final String COLOR_BOX_DISABLED = "button.box.disabled"; //$NON-NLS-1$
+	static final String COLOR_GRAYED = "button.gray"; //$NON-NLS-1$
+
 	protected final Button button;
 
 	public abstract Point computeDefaultSize();

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ColorProvider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ColorProvider.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Syntevo GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Thomas Singer (Syntevo) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.graphics.*;
+
+/**
+ * This is an (experimental) class to provide colors for custom-drawn controls.
+ * @noreference this is still experimental API and might be removed
+ */
+public interface ColorProvider {
+
+	/**
+	 * Returns the color associated with the specified key.
+	 *
+	 * @param key a non-null key
+	 * @return a non-null color
+	 */
+	Color getColor(String key);
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ControlRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ControlRenderer.java
@@ -22,7 +22,9 @@ import java.util.function.Function;
 
 public abstract class ControlRenderer {
 
-	protected static final Color DISABLED_COLOR = new Color(160, 160, 160);
+	protected static final String COLOR_DISABLED = "disabled"; //$NON-NLS-1$
+	public static final String COLOR_BACKGROUND = "background"; //$NON-NLS-1$
+	protected static final String COLOR_FOREGROUND = "foreground"; //$NON-NLS-1$
 
 	protected abstract void paint(GC gc, int width, int height);
 
@@ -37,6 +39,10 @@ public abstract class ControlRenderer {
 		paint(gc, size.x, size.y);
 	}
 
+	protected final Color getColor(String key) {
+		return control.getColorProvider().getColor(key);
+	}
+
 	protected final <T> T measure(Function<GC, T> function) {
 		return Drawing.measure(control, function);
 	}
@@ -46,10 +52,10 @@ public abstract class ControlRenderer {
 	}
 
 	public Color getDefaultBackground() {
-		return new Color(240, 240, 240);
+		return getColor(COLOR_BACKGROUND);
 	}
 
 	public Color getDefaultForeground() {
-		return new Color(0, 0, 0);
+		return getColor(COLOR_FOREGROUND);
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultArrowButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultArrowButtonRenderer.java
@@ -19,8 +19,6 @@ import org.eclipse.swt.graphics.*;
 
 public class DefaultArrowButtonRenderer extends ButtonRenderer {
 
-	private static final Color FOREGROUND_COLOR = new Color(0, 0, 0);
-
 	public DefaultArrowButtonRenderer(Button button) {
 		super(button);
 	}
@@ -40,7 +38,7 @@ public class DefaultArrowButtonRenderer extends ButtonRenderer {
 			gc.drawFocus(3, 3, width - 7, height - 7);
 		}
 
-		gc.setBackground(button.isEnabled() ? FOREGROUND_COLOR : DISABLED_COLOR);
+		gc.setBackground(getColor(button.isEnabled() ? COLOR_FOREGROUND : COLOR_DISABLED));
 
 		int centerHeight = height / 2;
 		int centerWidth = width / 2;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultButtonRenderer.java
@@ -19,12 +19,7 @@ import org.eclipse.swt.graphics.*;
 
 class DefaultButtonRenderer extends ButtonRenderer {
 
-	private static final Color BACKGROUND_COLOR = new Color(255, 255, 255);
-	private static final Color HOVER_COLOR = new Color(224, 238, 254);
-	private static final Color TOGGLE_COLOR = new Color(204, 228, 247);
-	private static final Color SELECTION_COLOR = new Color(0, 95, 184);
-	private static final Color BORDER_COLOR = new Color(160, 160, 160);
-	private static final Color BORDER_DISABLED_COLOR = new Color(192, 192, 192);
+	protected static final String COLOR_BACKGROUND = "button.background"; //$NON-NLS-1$
 
 	/**
 	 * Left and right margins
@@ -138,7 +133,7 @@ class DefaultButtonRenderer extends ButtonRenderer {
 
 		// Draw text
 		if (text != null && !text.isEmpty()) {
-			gc.setForeground(button.isEnabled() ? button.getForeground() : DISABLED_COLOR);
+			gc.setForeground(button.isEnabled() ? button.getForeground() : getColor(COLOR_DISABLED));
 			int textTopOffset = (height - 1 - textHeight) / 2;
 			int textLeftOffset = contentArea.x + imageSpace;
 			if (shiftDownRight) {
@@ -155,36 +150,38 @@ class DefaultButtonRenderer extends ButtonRenderer {
 
 	@Override
 	public Color getDefaultBackground() {
-		return BACKGROUND_COLOR;
+		return getColor(COLOR_BACKGROUND);
 	}
 
 	private void drawPushButton(GC gc, int w, int h) {
 		final boolean isToggle = (button.getStyle() & SWT.TOGGLE) != 0;
+		final String key;
 		if (button.isEnabled()) {
 			if (isToggle && button.getSelection()) {
-				gc.setBackground(TOGGLE_COLOR);
+				gc.setBackground(getColor(COLOR_TOGGLE));
 			} else if (isPressed()) {
-				gc.setBackground(TOGGLE_COLOR);
+				gc.setBackground(getColor(COLOR_TOGGLE));
 			} else if (isHover()) {
-				gc.setBackground(HOVER_COLOR);
+				gc.setBackground(getColor(COLOR_HOVER));
 			} else {
 				gc.setBackground(button.getBackground());
 			}
 			gc.fillRoundRectangle(0, 0, w, h, 6, 6);
 
-			if (isToggle && button.getSelection() || isHover()) {
-				gc.setForeground(SELECTION_COLOR);
-			} else {
-				gc.setForeground(BORDER_COLOR);
-			}
+			key = isToggle && button.getSelection() || isHover()
+					? COLOR_SELECTION
+					: COLOR_OUTLINE;
 		} else {
-			gc.setForeground(BORDER_DISABLED_COLOR);
+			key = COLOR_OUTLINE_DISABLED;
 		}
 
 		// if the button has focus, the border also changes the color
-		Color fg = gc.getForeground();
+		Color fg = getColor(key);
 		if (button.hasFocus()) {
-			gc.setForeground(SELECTION_COLOR);
+			gc.setForeground(getColor(COLOR_SELECTION));
+		}
+		else {
+			gc.setForeground(fg);
 		}
 		gc.drawRoundRectangle(0, 0, w - 1, h - 1, 6, 6);
 		gc.setForeground(fg);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultCheckboxRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultCheckboxRenderer.java
@@ -19,12 +19,6 @@ import org.eclipse.swt.graphics.*;
 
 public class DefaultCheckboxRenderer extends ButtonRenderer {
 
-	private static final Color HOVER_COLOR = new Color(224, 238, 254);
-	private static final Color SELECTION_COLOR = new Color(0, 95, 184);
-	private static final Color BORDER_DISABLED_COLOR = new Color(192, 192, 192);
-	private static final Color CHECKBOX_GRAYED_COLOR = new Color(192, 192, 192);
-	private static final Color BOX_COLOR = new Color(0, 0, 0);
-
 	/**
 	 * Left and right margins
 	 */
@@ -134,7 +128,7 @@ public class DefaultCheckboxRenderer extends ButtonRenderer {
 
 		// Draw text
 		if (text != null && !text.isEmpty()) {
-			gc.setForeground(button.isEnabled() ? button.getForeground() : DISABLED_COLOR);
+			gc.setForeground(button.isEnabled() ? button.getForeground() : getColor(COLOR_DISABLED));
 			int textTopOffset = (height - 1 - textHeight) / 2;
 			int textLeftOffset = contentArea.x + imageSpace;
 			gc.drawText(text, textLeftOffset, textTopOffset, DRAW_FLAGS);
@@ -151,9 +145,9 @@ public class DefaultCheckboxRenderer extends ButtonRenderer {
 		final boolean enabled = button.isEnabled();
 		final boolean selection = button.getSelection();
 		if (selection) {
-			gc.setBackground(enabled
-					? button.getGrayed() ? CHECKBOX_GRAYED_COLOR : SELECTION_COLOR
-					: DISABLED_COLOR);
+			gc.setBackground(getColor(enabled
+					? button.getGrayed() ? COLOR_GRAYED : COLOR_SELECTION
+					: COLOR_DISABLED));
 			int partialBoxBorder = 2;
 			gc.fillRoundRectangle(x + partialBoxBorder, y + partialBoxBorder,
 					BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1,
@@ -162,17 +156,17 @@ public class DefaultCheckboxRenderer extends ButtonRenderer {
 		}
 
 		if (!enabled) {
-			gc.setForeground(BORDER_DISABLED_COLOR);
-		} else if (isHover()) {
-			gc.setBackground(HOVER_COLOR);
-			int partialBoxBorder = selection ? 4 : 0;
-			gc.fillRoundRectangle(x + partialBoxBorder, y + partialBoxBorder,
-					BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1,
-					BOX_SIZE / 4 - partialBoxBorder / 2,
-					BOX_SIZE / 4 - partialBoxBorder / 2);
-		}
-		else {
-			gc.setForeground(BOX_COLOR);
+			gc.setForeground(getColor(COLOR_BOX_DISABLED));
+		} else {
+			gc.setForeground(getColor(COLOR_BOX));
+			if (isHover()) {
+				gc.setBackground(getColor(COLOR_HOVER));
+				int partialBoxBorder = selection ? 4 : 0;
+				gc.fillRoundRectangle(x + partialBoxBorder, y + partialBoxBorder,
+						BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1,
+						BOX_SIZE / 4 - partialBoxBorder / 2,
+						BOX_SIZE / 4 - partialBoxBorder / 2);
+			}
 		}
 		gc.drawRoundRectangle(x, y, BOX_SIZE, BOX_SIZE, 4, 4);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultColorProvider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultColorProvider.java
@@ -1,0 +1,220 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Syntevo GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Thomas Singer (Syntevo) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.RGB;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @noreference this is still experimental API and might be removed
+ */
+public final class DefaultColorProvider implements ColorProvider {
+
+	public static DefaultColorProvider createLightInstance() {
+		final float baseHue = 208;
+		final Color selection = hsb(baseHue, 1, 0.72f);
+
+		final Color black = gray(0);
+		final Color gray128 = gray(128);
+		final Color gray160 = gray(160);
+		final Color gray192 = gray(192);
+		final Color gray204 = gray(204);
+		final Color gray227 = gray(227);
+		final Color gray240 = gray(240);
+		final Color white = gray(255);
+
+		final Color backgroundPanel = gray227;
+		final Color backgroundInput = white;
+		final Color foreground = black;
+		final Color selectionBackground = hsb(baseHue, 0.2f, 1);
+		final Color selectionForeground = foreground;
+
+		final DefaultColorProvider p = new DefaultColorProvider();
+		p.put(ControlRenderer.COLOR_BACKGROUND, backgroundPanel);
+		p.put(ControlRenderer.COLOR_FOREGROUND, foreground);
+		p.put(ControlRenderer.COLOR_DISABLED, gray160);
+
+		p.put(DefaultTextRenderer.COLOR_BACKGROUND, backgroundInput);
+		p.put(DefaultTextRenderer.COLOR_BACKGROUND_READONLY, gray192);
+		p.put(DefaultTextRenderer.COLOR_FOREGROUND, foreground);
+		p.put(DefaultTextRenderer.COLOR_SELECTION_BACKGROUND, selectionBackground);
+		p.put(DefaultTextRenderer.COLOR_SELECTION_FOREGROUND, selectionForeground);
+		p.put(DefaultTextRenderer.COLOR_BORDER, gray128);
+
+		p.put(ButtonRenderer.COLOR_HOVER, hsb(baseHue, 0.1f, 1));
+		p.put(ButtonRenderer.COLOR_TOGGLE, hsb(baseHue, 0.2f, 0.96f));
+		p.put(ButtonRenderer.COLOR_SELECTION, selection);
+		p.put(ButtonRenderer.COLOR_OUTLINE, gray160);
+		p.put(ButtonRenderer.COLOR_OUTLINE_DISABLED, gray192);
+		p.put(ButtonRenderer.COLOR_BOX, gray128);
+		p.put(ButtonRenderer.COLOR_BOX_DISABLED, gray160);
+		p.put(ButtonRenderer.COLOR_GRAYED, gray192);
+
+		p.put(DefaultButtonRenderer.COLOR_BACKGROUND, white);
+
+		p.put(LabelRenderer.COLOR_SHADOW_IN1, gray160);
+		p.put(LabelRenderer.COLOR_SHADOW_IN2, white);
+		p.put(LabelRenderer.COLOR_SHADOW_OUT1, white);
+		p.put(LabelRenderer.COLOR_SHADOW_OUT2, gray160);
+
+		p.put(DefaultLinkRenderer.COLOR_LINK, hsb(baseHue, 1, 0.6f));
+
+		p.put(DefaultListRenderer.COLOR_BACKGROUND, backgroundInput);
+		p.put(DefaultListRenderer.COLOR_BORDER, gray160);
+		p.put(DefaultListRenderer.COLOR_SELECTION_BACKGROUND, selectionBackground);
+		p.put(DefaultListRenderer.COLOR_SELECTION_FOREGROUND, selectionForeground);
+
+		p.put(DefaultScaleRenderer.COLOR_HANDLE_IDLE, selection);
+		p.put(DefaultScaleRenderer.COLOR_HANDLE_HOVER, black);
+		p.put(DefaultScaleRenderer.COLOR_HANDLE_DRAG, gray204);
+		p.put(DefaultScaleRenderer.COLOR_HANDLE_OUTLINE, gray160);
+		p.put(DefaultScaleRenderer.COLOR_NOTCH, gray160);
+
+		p.put(DefaultSliderRenderer.COLOR_TRACK_BACKGROUND, gray240);
+		p.put(DefaultSliderRenderer.COLOR_TRACK_BORDER, gray204);
+		p.put(DefaultSliderRenderer.COLOR_THUMB_BACKGROUND, gray204);
+		p.put(DefaultSliderRenderer.COLOR_THUMB_BORDER, gray128);
+		p.put(DefaultSliderRenderer.COLOR_THUMB_HOVER, hsb(baseHue, 0.3f, 1));
+
+		p.put(DefaultToolBarRenderer.COLOR_SEPARATOR, gray160);
+		p.put(DefaultToolBarRenderer.COLOR_SHADOW_OUT, gray160);
+		p.put(DefaultToolBarRenderer.COLOR_HOVER_BACKGROUND, hsb(baseHue, 0.2f, 1));
+		p.put(DefaultToolBarRenderer.COLOR_HOVER_BORDER, hsb(baseHue, 0.3f, 1));
+		p.put(DefaultToolBarRenderer.COLOR_SELECTION_BACKGROUND, hsb(baseHue, 0.3f, 1));
+		p.put(DefaultToolBarRenderer.COLOR_SELECTION_BORDER, hsb(baseHue, 0.5f, 1));
+
+		return p;
+	}
+
+	public static DefaultColorProvider createDarkInstance() {
+		final float baseHue = 208;
+		final Color selection = hsb(baseHue, 0.5f, 0.5f);
+
+		final Color black = gray(0);
+		final Color gray30 = gray(30);
+		final Color gray64 = gray(64);
+		final Color gray80 = gray(80);
+		final Color gray128 = gray(128);
+		final Color gray160 = gray(160);
+		final Color gray192 = gray(192);
+		final Color gray204 = gray(204);
+
+		final Color backgroundPanel = gray30;
+		final Color backgroundInput = gray64;
+		// don't use a white as foreground color because we want to keep white as a color for bold text
+		// background: white normal text and white bold text look too similar
+		final Color foreground = gray192;
+		final Color selectionBackground = selection;
+		final Color selectionForeground = gray192;
+
+		final DefaultColorProvider p = new DefaultColorProvider();
+		p.put(ControlRenderer.COLOR_BACKGROUND, backgroundPanel);
+		p.put(ControlRenderer.COLOR_FOREGROUND, foreground);
+		p.put(ControlRenderer.COLOR_DISABLED, gray160);
+
+		p.put(DefaultTextRenderer.COLOR_BACKGROUND, backgroundInput);
+		p.put(DefaultTextRenderer.COLOR_BACKGROUND_READONLY, backgroundPanel);
+		p.put(DefaultTextRenderer.COLOR_FOREGROUND, foreground);
+		p.put(DefaultTextRenderer.COLOR_SELECTION_BACKGROUND, selectionBackground);
+		p.put(DefaultTextRenderer.COLOR_SELECTION_FOREGROUND, selectionForeground);
+		p.put(DefaultTextRenderer.COLOR_BORDER, gray128);
+
+		p.put(ButtonRenderer.COLOR_HOVER, gray80);
+		p.put(ButtonRenderer.COLOR_TOGGLE, gray128);
+		p.put(ButtonRenderer.COLOR_SELECTION, selection);
+		p.put(ButtonRenderer.COLOR_OUTLINE, gray128);
+		p.put(ButtonRenderer.COLOR_OUTLINE_DISABLED, gray80);
+		p.put(ButtonRenderer.COLOR_BOX, gray204);
+		p.put(ButtonRenderer.COLOR_BOX_DISABLED, gray160);
+		p.put(ButtonRenderer.COLOR_GRAYED, gray128);
+
+		p.put(DefaultButtonRenderer.COLOR_BACKGROUND, gray64);
+
+		p.put(LabelRenderer.COLOR_SHADOW_IN1, black);
+		p.put(LabelRenderer.COLOR_SHADOW_IN2, gray80);
+		p.put(LabelRenderer.COLOR_SHADOW_OUT1, gray80);
+		p.put(LabelRenderer.COLOR_SHADOW_OUT2, black);
+
+		p.put(DefaultLinkRenderer.COLOR_LINK, hsb(baseHue, 0.3f, 0.8f));
+
+		p.put(DefaultListRenderer.COLOR_BACKGROUND, backgroundInput);
+		p.put(DefaultListRenderer.COLOR_BORDER, gray80);
+		p.put(DefaultListRenderer.COLOR_SELECTION_BACKGROUND, selectionBackground);
+		p.put(DefaultListRenderer.COLOR_SELECTION_FOREGROUND, selectionForeground);
+
+		p.put(DefaultScaleRenderer.COLOR_HANDLE_IDLE, selection);
+		p.put(DefaultScaleRenderer.COLOR_HANDLE_HOVER, gray204);
+		p.put(DefaultScaleRenderer.COLOR_HANDLE_DRAG, gray128);
+		p.put(DefaultScaleRenderer.COLOR_HANDLE_OUTLINE, gray128);
+		p.put(DefaultScaleRenderer.COLOR_NOTCH, gray128);
+
+		p.put(DefaultSliderRenderer.COLOR_TRACK_BACKGROUND, gray30);
+		p.put(DefaultSliderRenderer.COLOR_TRACK_BORDER, gray64);
+		p.put(DefaultSliderRenderer.COLOR_THUMB_BACKGROUND, gray64);
+		p.put(DefaultSliderRenderer.COLOR_THUMB_BORDER, gray128);
+		p.put(DefaultSliderRenderer.COLOR_THUMB_HOVER, selection);
+
+		p.put(DefaultToolBarRenderer.COLOR_SEPARATOR, gray160);
+		p.put(DefaultToolBarRenderer.COLOR_SHADOW_OUT, gray160);
+		p.put(DefaultToolBarRenderer.COLOR_HOVER_BACKGROUND, gray80);
+		p.put(DefaultToolBarRenderer.COLOR_HOVER_BORDER, gray128);
+		p.put(DefaultToolBarRenderer.COLOR_SELECTION_BACKGROUND, gray128);
+		p.put(DefaultToolBarRenderer.COLOR_SELECTION_BORDER, gray160);
+		return p;
+	}
+
+	private final Map<String, Color> map = new HashMap<>();
+
+	private DefaultColorProvider() {
+	}
+
+	@Override
+	public Color getColor(String key) {
+		if (key == null) {
+			SWT.error(SWT.ERROR_NULL_ARGUMENT);
+		}
+		final Color color = map.get(key);
+		if (color == null) {
+			SWT.error(SWT.ERROR_UNSPECIFIED);
+		}
+		return color;
+	}
+
+	public void put(String key, Color color) {
+		map.put(key, color);
+	}
+
+	public static Color gray(int value) {
+		return new Color(value, value, value);
+	}
+
+	public static Color hsb(float baseHue, float saturation, float brightness) {
+		return new Color(new RGB(baseHue, saturation, brightness));
+	}
+
+	public static Color blend(Color color1, Color color2, float factor) {
+		return new Color(blend(color1.getRed(), color2.getRed(), factor),
+				blend(color1.getGreen(), color2.getGreen(), factor),
+				blend(color1.getBlue(), color2.getBlue(), factor));
+	}
+
+	private static int blend(int value1, int value2, float factor) {
+		int value = Math.round(value1 - (value1 - value2) * factor);
+		return Math.max(0, Math.min(value, 255));
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultLinkRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultLinkRenderer.java
@@ -21,7 +21,7 @@ import org.eclipse.swt.graphics.*;
 
 class DefaultLinkRenderer extends LinkRenderer {
 
-	private static final Color LINK_COLOR = new Color(0, 102, 204);
+	public static final String COLOR_LINK = "link.link"; //$NON-NLS-1$
 
 	private final Set<TextSegment> links = new HashSet<>();
 
@@ -40,9 +40,10 @@ class DefaultLinkRenderer extends LinkRenderer {
 
 		drawBackground(gc, width, height);
 
-		Color linkColor = link.getLinkForeground();
+		final Color linkColor = link.getLinkForeground();
 		final boolean enabled = link.isEnabled();
-		Color textColor = enabled ? link.getForeground() : DISABLED_COLOR;
+		final Color textColor = enabled ? link.getForeground() : getColor(COLOR_DISABLED);
+		final int lineHeight = gc.getFontMetrics().getHeight();
 
 		links.clear();
 
@@ -78,7 +79,7 @@ class DefaultLinkRenderer extends LinkRenderer {
 
 				lineX += extent.x;
 			}
-			lineY += gc.getFontMetrics().getHeight();
+			lineY += lineHeight;
 		}
 	}
 
@@ -167,6 +168,6 @@ class DefaultLinkRenderer extends LinkRenderer {
 
 	@Override
 	public Color getDefaultLinkColor() {
-		return LINK_COLOR;
+		return getColor(COLOR_LINK);
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultListRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultListRenderer.java
@@ -39,11 +39,6 @@ public class DefaultListRenderer extends ListRenderer {
 		}
 	}
 
-	@Override
-	public Color getDefaultBackground() {
-		return new Color(255, 255, 255);
-	}
-
 	private void drawBackground(Rectangle clientArea, GC gc) {
 		if ((list.getState() & Widget.PARENT_BACKGROUND) == 0) {
 			gc.setBackground(list.getBackground());
@@ -53,7 +48,7 @@ public class DefaultListRenderer extends ListRenderer {
 
 		if ((list.getStyle() & SWT.BORDER) != 0 && list.isEnabled()) {
 			Color foreground = gc.getForeground();
-			gc.setForeground(list.getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY));
+			gc.setForeground(getColor(COLOR_BORDER));
 			gc.drawLine(clientArea.x, clientArea.y + clientArea.height - 1,
 					clientArea.x + clientArea.x + clientArea.width - 1, clientArea.y + clientArea.height - 1);
 			gc.setForeground(foreground);
@@ -88,7 +83,7 @@ public class DefaultListRenderer extends ListRenderer {
 			}
 		} else {
 			Color foreground = gc.getForeground();
-			gc.setForeground(list.getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY));
+			gc.setForeground(getColor(COLOR_DISABLED));
 			gc.drawText(text, _x, y, true);
 
 			gc.setForeground(foreground);
@@ -98,8 +93,8 @@ public class DefaultListRenderer extends ListRenderer {
 	private void drawSelectedText(String text, GC gc, int _x, int _y, Rectangle clientArea, Point textExtent) {
 		Color background = gc.getBackground();
 		Color foreground = gc.getForeground();
-		gc.setForeground(list.getDisplay().getSystemColor(SWT.COLOR_LIST_SELECTION_TEXT));
-		gc.setBackground(list.getDisplay().getSystemColor(SWT.COLOR_LIST_SELECTION));
+		gc.setForeground(getColor(COLOR_SELECTION_FOREGROUND));
+		gc.setBackground(getColor(COLOR_SELECTION_BACKGROUND));
 		gc.fillRectangle(0, _y, clientArea.width, textExtent.y);
 		gc.drawText(text, _x, _y);
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultRadioButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultRadioButtonRenderer.java
@@ -19,11 +19,6 @@ import org.eclipse.swt.graphics.*;
 
 public class DefaultRadioButtonRenderer extends ButtonRenderer {
 
-	private static final Color HOVER_COLOR = new Color(224, 238, 254);
-	private static final Color SELECTION_COLOR = new Color(0, 95, 184);
-	private static final Color BORDER_DISABLED_COLOR = new Color(192, 192, 192);
-	private static final Color BOX_COLOR = new Color(0, 0, 0);
-
 	/**
 	 * Left and right margins
 	 */
@@ -133,7 +128,7 @@ public class DefaultRadioButtonRenderer extends ButtonRenderer {
 
 		// Draw text
 		if (text != null && !text.isEmpty()) {
-			gc.setForeground(button.isEnabled() ? button.getForeground() : DISABLED_COLOR);
+			gc.setForeground(button.isEnabled() ? button.getForeground() : getColor(COLOR_DISABLED));
 			int textTopOffset = (height - 1 - textHeight) / 2;
 			int textLeftOffset = contentArea.x + imageSpace;
 			gc.drawText(text, textLeftOffset, textTopOffset, DRAW_FLAGS);
@@ -150,22 +145,22 @@ public class DefaultRadioButtonRenderer extends ButtonRenderer {
 		final boolean enabled = button.isEnabled();
 		final boolean selection = button.getSelection();
 		if (selection) {
-			gc.setBackground(enabled ? SELECTION_COLOR : DISABLED_COLOR);
+			gc.setBackground(getColor(enabled ? COLOR_SELECTION : COLOR_DISABLED));
 			int partialBoxBorder = 2;
 			gc.fillOval(x + partialBoxBorder, y + partialBoxBorder,
 					BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1);
 		}
 
 		if (enabled) {
-			gc.setForeground(BOX_COLOR);
+			gc.setForeground(getColor(COLOR_BOX));
 			if (isHover()) {
-				gc.setBackground(HOVER_COLOR);
+				gc.setBackground(getColor(COLOR_HOVER));
 				int partialBoxBorder = selection ? 4 : 0;
 				gc.fillOval(x + partialBoxBorder, y + partialBoxBorder,
 						BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1);
 			}
 		} else {
-			gc.setForeground(BORDER_DISABLED_COLOR);
+			gc.setForeground(getColor(COLOR_BOX_DISABLED));
 		}
 		gc.drawOval(x, y, BOX_SIZE, BOX_SIZE);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultScaleRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultScaleRenderer.java
@@ -21,10 +21,11 @@ class DefaultScaleRenderer extends ScaleRenderer {
 	private static final int PREFERRED_WIDTH = 170;
 	private static final int PREFERRED_HEIGHT = 42;
 
-	private static final Color IDLE_COLOR = new Color(0, 95, 184);
-	private static final Color HOVER_COLOR = new Color(0, 0, 0);
-	private static final Color DRAG_COLOR = new Color(204, 204, 204);
-	private static final Color LINE_COLOR = new Color(160, 160, 160);
+	static final String COLOR_HANDLE_IDLE = "scale.handle.background"; //$NON-NLS-1$
+	static final String COLOR_HANDLE_HOVER = "scale.handle.background.hover"; //$NON-NLS-1$
+	static final String COLOR_HANDLE_DRAG = "scale.handle.background.drag"; //$NON-NLS-1$
+	static final String COLOR_HANDLE_OUTLINE = "scale.handle.outline"; //$NON-NLS-1$
+	static final String COLOR_NOTCH = "scale.notch.foreground"; //$NON-NLS-1$
 
 	/**
 	 * Pixel per Unit. Ratio of how many pixels are used to display one unit of the
@@ -77,12 +78,11 @@ class DefaultScaleRenderer extends ScaleRenderer {
 			lastNotch = bar.y + bar.height - 5;
 		}
 
-		gc.fillRectangle(bar);
-		gc.setForeground(LINE_COLOR);
+		gc.setForeground(getColor(COLOR_HANDLE_OUTLINE));
 		gc.drawRectangle(bar);
 
 		// prepare for line drawing
-		gc.setForeground(LINE_COLOR);
+		gc.setForeground(getColor(COLOR_NOTCH));
 		gc.setLineWidth(1);
 
 		// draw first and last notch
@@ -113,18 +113,17 @@ class DefaultScaleRenderer extends ScaleRenderer {
 	}
 
 	private void drawHandle(GC gc, int value) {
-		// draw handle
-		Color handleColor;
+		final String colorKey;
 		if (scale.isEnabled()) {
-			handleColor = switch (getHandleState()) {
-				case IDLE -> IDLE_COLOR;
-				case HOVER -> HOVER_COLOR;
-				case DRAG -> DRAG_COLOR;
+			colorKey = switch (getHandleState()) {
+				case IDLE -> COLOR_HANDLE_IDLE;
+				case HOVER -> COLOR_HANDLE_HOVER;
+				case DRAG -> COLOR_HANDLE_DRAG;
 			};
 		} else {
-			handleColor = DISABLED_COLOR;
+			colorKey = ControlRenderer.COLOR_DISABLED;
 		}
-		gc.setBackground(handleColor);
+		gc.setBackground(getColor(colorKey));
 		handleBounds = calculateHandleBounds(value);
 		gc.fillRectangle(handleBounds);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultSliderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultSliderRenderer.java
@@ -19,11 +19,11 @@ class DefaultSliderRenderer extends SliderRenderer {
 	private static final int PREFERRED_WIDTH = 170;
 	private static final int PREFERRED_HEIGHT = 18;
 
-	private static final Color TRACK_BACKGROUND = new Color(240, 240, 240);
-	private static final Color TRACK_FOREGROUND = new Color(204, 204, 204);
-	private static final Color THUMB_BACKGROUND = new Color(204, 204, 204);
-	private static final Color THUMB_FOREGROUND = new Color(133, 133, 133);
-	private static final Color THUMB_HOVER_COLOR = new Color(135, 206, 235);
+	static final String COLOR_TRACK_BACKGROUND = "slider.track.background"; //$NON-NLS-1$
+	static final String COLOR_TRACK_BORDER = "slider.track.border"; //$NON-NLS-1$
+	static final String COLOR_THUMB_BACKGROUND = "slider.thumb.background"; //$NON-NLS-1$
+	static final String COLOR_THUMB_BORDER = "slider.thumb.border"; //$NON-NLS-1$
+	static final String COLOR_THUMB_HOVER = "slider.thumb.hover"; //$NON-NLS-1$
 
 	private boolean drawTrack;
 
@@ -48,7 +48,7 @@ class DefaultSliderRenderer extends SliderRenderer {
 		gc.setBackground(slider.getBackground());
 		gc.fillRectangle(0, 0, width, height);
 
-		gc.setForeground(slider.isEnabled() ? slider.getForeground() : DISABLED_COLOR);
+		gc.setForeground(slider.isEnabled() ? slider.getForeground() : getColor(COLOR_DISABLED));
 
 		if (slider.isVertical()) {
 			int trackX = (width - 7) / 2;
@@ -84,20 +84,16 @@ class DefaultSliderRenderer extends SliderRenderer {
 			gc.drawLine(0, 0, width, 0);
 		}
 
-		gc.setForeground(TRACK_FOREGROUND);
+		gc.setForeground(getColor(COLOR_TRACK_BORDER));
 		// Draw the track
 		if (drawTrack) {
-			gc.setBackground(TRACK_BACKGROUND);
+			gc.setBackground(getColor(COLOR_TRACK_BACKGROUND));
 			drawRoundRectWithBorder(gc, trackRectangle);
 		}
 
 		// Draw the thumb
-		if (thumbHovered || isDragging) {
-			gc.setBackground(THUMB_HOVER_COLOR);
-		} else {
-			gc.setBackground(THUMB_BACKGROUND);
-		}
-		gc.setForeground(THUMB_FOREGROUND);
+		gc.setBackground(getColor(thumbHovered || isDragging ? COLOR_THUMB_HOVER : COLOR_THUMB_BACKGROUND));
+		gc.setForeground(getColor(COLOR_THUMB_BORDER));
 		drawRoundRectWithBorder(gc, thumbRectangle);
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultTextRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultTextRenderer.java
@@ -8,13 +8,12 @@ import org.eclipse.swt.graphics.Rectangle;
 
 public class DefaultTextRenderer extends TextRenderer {
 
-	private static final Color DISABLED_COLOR = new Color(160, 160, 160);
-	private static final Color TEXT_COLOR = new Color(0, 0, 0);
-	private static final Color BACKGROUND_COLOR = new Color(255, 255, 255);
-	private static final Color BORDER_COLOR = new Color(128, 128, 128);
-	private static final Color READONLY_BACKGROUND_COLOR = new Color(227, 227, 227);
-	private static final Color SELECTION_BACKGROUND_COLOR = new Color(0, 120, 215);
-	private static final Color SELECTION_TEXT_COLOR = new Color(255, 255, 255);
+	static final String COLOR_FOREGROUND = "text.foreground"; //$NON-NLS-1$
+	static final String COLOR_BACKGROUND = "text.background"; //$NON-NLS-1$
+	static final String COLOR_BORDER = "text.border"; //$NON-NLS-1$
+	static final String COLOR_BACKGROUND_READONLY = "text.background.readonly"; //$NON-NLS-1$
+	static final String COLOR_SELECTION_BACKGROUND = "text.selection.background"; //$NON-NLS-1$
+	static final String COLOR_SELECTION_FOREGROUND = "text.selection.foreground"; //$NON-NLS-1$
 
 	public DefaultTextRenderer(Text text, TextModel model) {
 		super(text, model);
@@ -24,13 +23,13 @@ public class DefaultTextRenderer extends TextRenderer {
 	protected void paint(GC gc, int width, int height) {
 		final boolean enabled = text.isEnabled();
 		if (!enabled) {
-			gc.setForeground(DISABLED_COLOR);
+			gc.setForeground(getColor(COLOR_DISABLED));
 		}
 
 		final int style = text.getStyle();
 		final boolean editable = text.getEditable();
 		if (!enabled || ((style & SWT.BORDER) == 1 && !editable)) {
-			gc.setBackground(READONLY_BACKGROUND_COLOR);
+			gc.setBackground(getColor(COLOR_BACKGROUND_READONLY));
 		}
 
 		final Rectangle visibleArea = getVisibleArea();
@@ -46,12 +45,12 @@ public class DefaultTextRenderer extends TextRenderer {
 
 	@Override
 	public Color getDefaultBackground() {
-		return BACKGROUND_COLOR;
+		return getColor(COLOR_BACKGROUND);
 	}
 
 	@Override
 	public Color getDefaultForeground() {
-		return TEXT_COLOR;
+		return getColor(COLOR_FOREGROUND);
 	}
 
 	@Override
@@ -112,7 +111,7 @@ public class DefaultTextRenderer extends TextRenderer {
 		gc.fillRectangle(clientArea.x, clientArea.y, clientArea.width, height);
 		if (drawLine) {
 			Color prevBackground = gc.getBackground();
-			gc.setBackground(text.isFocusControl() ? SELECTION_BACKGROUND_COLOR : BORDER_COLOR);
+			gc.setBackground(getColor(text.isFocusControl() ? COLOR_SELECTION_BACKGROUND : COLOR_BORDER));
 			gc.fillRectangle(clientArea.x, clientArea.y + height, clientArea.width, 1);
 			gc.setBackground(prevBackground);
 		}
@@ -157,8 +156,8 @@ public class DefaultTextRenderer extends TextRenderer {
 
 			Color oldForeground = gc.getForeground();
 			Color oldBackground = gc.getBackground();
-			gc.setForeground(SELECTION_TEXT_COLOR);
-			gc.setBackground(SELECTION_BACKGROUND_COLOR);
+			gc.setForeground(getColor(COLOR_SELECTION_FOREGROUND));
+			gc.setBackground(getColor(COLOR_SELECTION_BACKGROUND));
 			for (int i = startLocation.line; i <= endLocation.line; i++) {
 				TextLocation location = new TextLocation(i, 0);
 				String text = textLines[i];

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultToolBarRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultToolBarRenderer.java
@@ -26,7 +26,12 @@ import org.eclipse.swt.widgets.ToolBarLayout.*;
  */
 class DefaultToolBarRenderer extends ToolBarRenderer {
 
-	public static final Color COLOR_SEPARATOR = new Color(Display.getDefault(), 160, 160, 160);
+	public static final String COLOR_SEPARATOR = "toolbar.separator"; //$NON-NLS-1$
+	public static final String COLOR_SHADOW_OUT = "toolbar.shadowOut"; //$NON-NLS-1$
+	public static final String COLOR_HOVER_BACKGROUND = "toolbar.background.hover"; //$NON-NLS-1$
+	public static final String COLOR_HOVER_BORDER = "toolbar.border.hover"; //$NON-NLS-1$
+	public static final String COLOR_SELECTION_BACKGROUND = "toolbar.background.selection"; //$NON-NLS-1$
+	public static final String COLOR_SELECTION_BORDER = "toolbar.selection.border"; //$NON-NLS-1$
 
 	private int rowCount = SWT.DEFAULT;
 
@@ -44,8 +49,12 @@ class DefaultToolBarRenderer extends ToolBarRenderer {
 	}
 
 	private void render(GC gc, Point size, List<Row> rows) {
+		final ColorProvider colorProvider = toolBar.getDisplay().getColorProvider();
+		gc.setBackground(toolBar.getBackground());
+		gc.fillRectangle(0, 0, size.x, size.y);
+
 		if (toolBar.isShadowOut()) {
-			gc.setForeground(new Color(160, 160, 160));
+			gc.setForeground(colorProvider.getColor(COLOR_SHADOW_OUT));
 			gc.drawLine(0, 0, size.x, 0);
 		}
 
@@ -55,14 +64,14 @@ class DefaultToolBarRenderer extends ToolBarRenderer {
 				item.render(gc, itemRecord.bounds());
 			}
 			if (row.hasRowSeparator) {
-				drawHorizontalSeparator(gc, row);
+				drawHorizontalSeparator(gc, row, colorProvider);
 			}
 		}
 	}
 
-	private void drawHorizontalSeparator(GC gc, Row row) {
+	private void drawHorizontalSeparator(GC gc, Row row, ColorProvider colorProvider) {
 		int pos = row.position + row.usedSpace.y + 3;
-		gc.setForeground(COLOR_SEPARATOR);
+		gc.setForeground(colorProvider.getColor(COLOR_SEPARATOR));
 		gc.drawLine(0, pos, row.availableSpace.y, pos);
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
@@ -113,7 +113,6 @@ public class Label extends CustomControl {
 		final RendererFactory rendererFactory = parent.getDisplay().getRendererFactory();
 		renderer = rendererFactory.createLabelRenderer(this);
 		renderer.setAlign(align);
-		renderer.setForeground(getForeground());
 
 		final Listener listener = event -> {
 			switch (event.type) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LabelRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LabelRenderer.java
@@ -18,6 +18,11 @@ import org.eclipse.swt.graphics.*;
 
 public abstract class LabelRenderer extends ControlRenderer {
 
+	protected static final String COLOR_SHADOW_IN1 = "label.shadowIn1"; //$NON-NLS-1$
+	protected static final String COLOR_SHADOW_IN2 = "label.shadowIn2"; //$NON-NLS-1$
+	protected static final String COLOR_SHADOW_OUT1 = "label.shadowOut1"; //$NON-NLS-1$
+	protected static final String COLOR_SHADOW_OUT2 = "label.shadowOut2"; //$NON-NLS-1$
+
 	public abstract Point computeDefaultSize();
 
 	/** a string inserted in the middle of text that has been shortened */
@@ -44,7 +49,6 @@ public abstract class LabelRenderer extends ControlRenderer {
 	private int[] gradientPercents;
 	private boolean gradientVertical;
 	private Color background;
-	private Color foreground;
 
 	private int leftMargin = DEFAULT_MARGIN;
 	private int topMargin = DEFAULT_MARGIN;
@@ -115,7 +119,7 @@ public abstract class LabelRenderer extends ControlRenderer {
 	}
 
 	public Color getBackground() {
-		return background;
+		return background != null ? background : getColor(COLOR_BACKGROUND);
 	}
 
 	public void setBackground(Color color) {
@@ -139,11 +143,7 @@ public abstract class LabelRenderer extends ControlRenderer {
 	}
 
 	public Color getForeground() {
-		return foreground;
-	}
-
-	public void setForeground(Color foreground) {
-		this.foreground = foreground;
+		return label.getForeground();
 	}
 
 	public Color[] getGradientColors() {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Link.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Link.java
@@ -434,10 +434,7 @@ public class Link extends CustomControl {
 	public void setLinkForeground(Color color) {
 		checkWidget();
 
-		if (color == null) {
-			return;
-		}
-		if (color.equals(linkColor)) {
+		if (Objects.equals(color, linkColor)) {
 			return;
 		}
 
@@ -490,7 +487,6 @@ public class Link extends CustomControl {
 		}
 		this.leftMargin = leftMargin;
 		redraw();
-
 	}
 
 	/**
@@ -529,7 +525,6 @@ public class Link extends CustomControl {
 		}
 		this.rightMargin = rightMargin;
 		redraw();
-
 	}
 
 	/**
@@ -604,7 +599,6 @@ public class Link extends CustomControl {
 		}
 		this.bottomMargin = bottomMargin;
 		redraw();
-
 	}
 
 	/**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ListRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ListRenderer.java
@@ -1,8 +1,14 @@
 package org.eclipse.swt.widgets;
 
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
 
 public abstract class ListRenderer extends ControlRenderer {
+
+	public static final String COLOR_BACKGROUND = "list.background"; //$NON-NLS-1$
+	public static final String COLOR_BORDER = "list.border"; //$NON-NLS-1$
+	public static final String COLOR_SELECTION_BACKGROUND = "list.selection.background"; //$NON-NLS-1$
+	public static final String COLOR_SELECTION_FOREGROUND = "list.selection.foreground"; //$NON-NLS-1$
 
 	public abstract Point computeDefaultSize();
 
@@ -15,5 +21,10 @@ public abstract class ListRenderer extends ControlRenderer {
 	public ListRenderer(List list) {
 		super(list);
 		this.list = list;
+	}
+
+	@Override
+	public Color getDefaultBackground() {
+		return getColor(COLOR_BACKGROUND);
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolItemButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolItemButtonRenderer.java
@@ -38,12 +38,17 @@ class ToolItemButtonRenderer implements ToolItemRenderer {
 	private Rectangle bounds = new Rectangle(0, 0, 0, 0);
 
 	public enum ColorType {
-		BORDER_DOWN(0.4f), BORDER_HOVER(0.2f), FILL_DOWN(0.2f), FILL_HOVER(0.1f);
+		BORDER_DOWN(0.4f, DefaultToolBarRenderer.COLOR_SELECTION_BORDER),
+		BORDER_HOVER(0.2f, DefaultToolBarRenderer.COLOR_HOVER_BORDER),
+		FILL_DOWN(0.2f, DefaultToolBarRenderer.COLOR_SELECTION_BACKGROUND),
+		FILL_HOVER(0.1f, DefaultToolBarRenderer.COLOR_HOVER_BACKGROUND);
 
-		final float ratio;
+		private final float ratio;
+		private final String key;
 
-		private ColorType(float ratio) {
+		ColorType(float ratio, String key) {
 			this.ratio = ratio;
+			this.key = key;
 		}
 	}
 
@@ -126,12 +131,11 @@ class ToolItemButtonRenderer implements ToolItemRenderer {
 
 	private Color getColor(ColorType type) {
 		Color backgroundColor = item.getBackground();
-		RGB set;
-		if (backgroundColor != null) {
-			set = backgroundColor.getRGB();
-		} else {
-			set = DEFAULT_RGB;
+		if (backgroundColor == null) {
+			return bar.getDisplay().getColorProvider().getColor(type.key);
 		}
+
+		RGB set = backgroundColor.getRGB();
 
 		int red = Math.round(set.red - (set.red - TARGET_RGB.red) * type.ratio);
 		int green = Math.round(set.green - (set.green - TARGET_RGB.green) * type.ratio);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Control.java
@@ -6875,4 +6875,7 @@ Point getSurfaceOrigin () {
 	return success ? new Point((int)originX[0], (int)originY[0]) : new Point(0, 0);
 }
 
+protected final ColorProvider getColorProvider() {
+	return display.getColorProvider();
+}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Display.java
@@ -502,6 +502,7 @@ public class Display extends Device implements Executor {
 	static Display [] Displays = new Display [1];
 
 	/* Skinning support */
+	private ColorProvider colorProvider;
 	private RendererFactory rendererFactory;
 	Widget [] skinList = new Widget [GROW_SIZE];
 	int skinCount;
@@ -633,6 +634,7 @@ public Display () {
 public Display (DeviceData data) {
 	super (data);
 
+	colorProvider = DefaultColorProvider.createLightInstance();
 	rendererFactory = new DefaultRendererFactory();
 }
 
@@ -6318,5 +6320,25 @@ public RendererFactory getRendererFactory() {
 public void setRendererFactory(RendererFactory rendererFactory) {
 	if (rendererFactory == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	this.rendererFactory = rendererFactory;
+}
+
+/**
+ * Return the color provider used for custom-drawn controls.
+ * @return a non-null instance of the color provider
+ * @noreference this is still experimental API and might be removed
+ */
+public final ColorProvider getColorProvider() {
+	return colorProvider;
+}
+
+/**
+ * Set the color provider used for custom-drawn controls.
+ * @param colorProvider a non-null color provider
+ * @noreference this is still experimental API and might be removed
+ */
+public final void setColorProvider(ColorProvider colorProvider) {
+	if (colorProvider == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	this.colorProvider = colorProvider;
+	// todo: redraw all (custom-drawn) widgets
 }
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Control.java
@@ -5880,5 +5880,9 @@ private static void resizeFont(Control control, int newZoom) {
 		control.setFont(Font.win32_new(font, newZoom));
 	}
 }
+
+protected final ColorProvider getColorProvider() {
+	return display.getColorProvider();
+}
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Display.java
@@ -532,6 +532,7 @@ public class Display extends Device implements Executor {
 	static int SWT_OPENDOC;
 
 	/* Skinning support */
+	private ColorProvider colorProvider;
 	private RendererFactory rendererFactory;
 	Widget [] skinList = new Widget [GROW_SIZE];
 	int skinCount;
@@ -596,6 +597,7 @@ public Display () {
 public Display (DeviceData data) {
 	super (data);
 
+	colorProvider = DefaultColorProvider.createLightInstance();
 	rendererFactory = new DefaultRendererFactory();
 }
 
@@ -5405,5 +5407,25 @@ public RendererFactory getRendererFactory() {
 public void setRendererFactory(RendererFactory rendererFactory) {
 	if (rendererFactory == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
 	this.rendererFactory = rendererFactory;
+}
+
+/**
+ * Return the color provider used for custom-drawn controls.
+ * @return a non-null instance of the color provider
+ * @noreference this is still experimental API and might be removed
+ */
+public final ColorProvider getColorProvider() {
+	return colorProvider;
+}
+
+/**
+ * Set the color provider used for custom-drawn controls.
+ * @param colorProvider a non-null color provider
+ * @noreference this is still experimental API and might be removed
+ */
+public final void setColorProvider(ColorProvider colorProvider) {
+	if (colorProvider == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+	this.colorProvider = colorProvider;
+	// todo: redraw all (custom-drawn) widgets
 }
 }

--- a/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/ColorProviderSnippet.java
+++ b/tests/org.eclipse.swt.tests/ManualTests/org/eclipse/swt/tests/manual/ColorProviderSnippet.java
@@ -1,0 +1,126 @@
+package org.eclipse.swt.tests.manual;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.layout.*;
+import org.eclipse.swt.widgets.*;
+
+public class ColorProviderSnippet {
+
+	public static void main(String[] args) {
+		final Display display = new Display();
+
+		final Shell shell = new Shell(display);
+		shell.setLayout(new GridLayout(2, true));
+		shell.setBackgroundMode(SWT.INHERIT_DEFAULT);
+
+		final Label label = new Label(shell, SWT.NONE);
+		label.setText("Label");
+		label.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false, 2, 1));
+
+		final Label shadowOut = new Label(shell, SWT.SHADOW_OUT);
+		shadowOut.setText("Shadow out");
+		shadowOut.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
+
+		final Label shadowIn = new Label(shell, SWT.SHADOW_IN);
+		shadowIn.setText("Shadow in");
+		shadowIn.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
+
+		final Link link = new Link(shell, SWT.NONE);
+		link.setText("Link <a href=\"foo\">target</a>");
+		link.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false, 2, 1));
+
+		final Button pushButton = new Button(shell, SWT.PUSH);
+		pushButton.setText("Push");
+		pushButton.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false, 2, 1));
+
+		final Button checkbox = new Button(shell, SWT.CHECK);
+		checkbox.setText("Checkbox");
+		checkbox.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
+
+		final Button checkboxTristate = new Button(shell, SWT.CHECK);
+		checkboxTristate.setSelection(true);
+		checkboxTristate.setGrayed(true);
+		checkboxTristate.setText("Checkbox tristate");
+		checkboxTristate.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
+
+		final Button radio = new Button(shell, SWT.RADIO);
+		radio.setText("Radio");
+		radio.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false, 2, 1));
+
+		final Scale scale = new Scale(shell, SWT.HORIZONTAL);
+		scale.setSelection(50);
+		scale.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false, 2, 1));
+
+		final Text textSingle = new Text(shell, SWT.SINGLE);
+		textSingle.setText("Text");
+		textSingle.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
+
+		final Text textMulti = new Text(shell, SWT.MULTI);
+		textMulti.setText("Multiline\ntext");
+		textMulti.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		final ToolBar toolBar = new ToolBar(shell, SWT.NORMAL);
+		toolBar.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1));
+		new ToolItem(toolBar, SWT.PUSH).setText("Push");
+		new ToolItem(toolBar, SWT.CHECK).setText("Check");
+
+		final Slider slider = new Slider(shell, SWT.HORIZONTAL);
+		slider.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1));
+		slider.setValues(50, 0, 100, 5, 1, 5);
+
+		final List list = new List(shell, SWT.BORDER);
+		list.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 2, 1));
+		list.setItems("Item 1", "Item 2", "Item 3", "Item 4", "Item 5");
+
+		final Button enabledChkBx = new Button(shell, SWT.CHECK);
+		enabledChkBx.setText("enabled");
+		enabledChkBx.setSelection(true);
+		enabledChkBx.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
+		enabledChkBx.addListener(SWT.Selection, e -> {
+			final boolean enabled = enabledChkBx.getSelection();
+			label.setEnabled(enabled);
+			shadowOut.setEnabled(enabled);
+			shadowIn.setEnabled(enabled);
+			link.setEnabled(enabled);
+			pushButton.setEnabled(enabled);
+			checkbox.setEnabled(enabled);
+			checkboxTristate.setEnabled(enabled);
+			radio.setEnabled(enabled);
+			scale.setEnabled(enabled);
+			textSingle.setEnabled(enabled);
+			textMulti.setEnabled(enabled);
+			toolBar.setEnabled(enabled);
+			slider.setEnabled(enabled);
+			list.setEnabled(enabled);
+		});
+
+		final Button darkChkBx = new Button(shell, SWT.CHECK);
+		darkChkBx.setText("dark");
+		darkChkBx.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
+		darkChkBx.addListener(SWT.Selection, e -> {
+			final ColorProvider colorProvider = darkChkBx.getSelection()
+					? DefaultColorProvider.createDarkInstance()
+					: DefaultColorProvider.createLightInstance();
+			display.setColorProvider(colorProvider);
+			shell.setBackground(colorProvider.getColor(ControlRenderer.COLOR_BACKGROUND));
+			shell.redraw();
+			for (Control child : shell.getChildren()) {
+				child.redraw();
+			}
+		});
+
+		final Point size = shell.computeSize(SWT.DEFAULT, SWT.DEFAULT);
+		size.x = Math.max(size.x, 300);
+		shell.setSize(size);
+		shell.open();
+
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch()) {
+				display.sleep();
+			}
+		}
+
+		display.dispose();
+	}
+}


### PR DESCRIPTION
Please start `ColorProviderTest` to test.

Note, that the color provider, the color constants and the renderer are closely linked. In the future there will be exchangeable renderers which then need an own color provider (e.g. because a different renderer needs more/less colors).

Feedback is welcome.