### PR TITLE
Drawing.getTextExtent with optimized SkijaGC

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaCanvasTest.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaCanvasTest.java
@@ -26,7 +26,7 @@ public class SkijaCanvasTest {
 		shell.setVisible(true);
 
 		shell.addPaintListener(event -> {
-			SkijaGC skijaGC = new SkijaGC((NativeGC) event.gc.innerGC, false);
+			SkijaGC skijaGC = SkijaGC.createDefaultInstance((NativeGC) event.gc.innerGC);
 
 			skijaGC.drawText("Hello World Test", 0, 0);
 			skijaGC.drawLine(0, 0, 200, 200);

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaCanvasTest.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaCanvasTest.java
@@ -26,7 +26,7 @@ public class SkijaCanvasTest {
 		shell.setVisible(true);
 
 		shell.addPaintListener(event -> {
-			SkijaGC skijaGC = new SkijaGC((NativeGC) event.gc.innerGC, null);
+			SkijaGC skijaGC = new SkijaGC((NativeGC) event.gc.innerGC, false);
 
 			skijaGC.drawText("Hello World Test", 0, 0);
 			skijaGC.drawLine(0, 0, 200, 200);

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaDrawImage.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaDrawImage.java
@@ -32,7 +32,7 @@ public class SkijaDrawImage {
 		gc.dispose ();
 
 		shell.addPaintListener(event -> {
-			SkijaGC skijaGC = new SkijaGC((NativeGC) event.gc.innerGC, false);
+			SkijaGC skijaGC = SkijaGC.createDefaultInstance((NativeGC) event.gc.innerGC);
 
 			skijaGC.drawImage(image, 0, 0);
 			skijaGC.drawText("Test", 0, 0);

--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaDrawImage.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaDrawImage.java
@@ -32,7 +32,7 @@ public class SkijaDrawImage {
 		gc.dispose ();
 
 		shell.addPaintListener(event -> {
-			SkijaGC skijaGC = new SkijaGC((NativeGC) event.gc.innerGC, null);
+			SkijaGC skijaGC = new SkijaGC((NativeGC) event.gc.innerGC, false);
 
 			skijaGC.drawImage(image, 0, 0);
 			skijaGC.drawText("Test", 0, 0);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Drawing.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Drawing.java
@@ -23,6 +23,10 @@ public final class Drawing {
 	}
 
 	public static GC createGraphicsContext(GC originalGC) {
+		return createGraphicsContext(originalGC, false);
+	}
+
+	private static GC createGraphicsContext(GC originalGC, boolean onlyForMeasuring) {
 		if (!SWT.USE_SKIJA) {
 			return originalGC;
 		}
@@ -32,7 +36,7 @@ public final class Drawing {
 		}
 
 		GC gc = new GC();
-		gc.innerGC = new SkijaGC(originalNativeGC, null);
+		gc.innerGC = new SkijaGC(originalNativeGC, onlyForMeasuring);
 		return gc;
 	}
 
@@ -132,4 +136,15 @@ public final class Drawing {
 		}
 	}
 
+	public static Point getTextExtent(CustomControl control, String text, int drawFlags) {
+		GC originalGC = new GC(control);
+		GC gc = createGraphicsContext(originalGC, true);
+		try {
+			gc.setFont(control.getFont());
+			return gc.textExtent(text, drawFlags);
+		} finally {
+			gc.dispose();
+			originalGC.dispose();
+		}
+	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Drawing.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Drawing.java
@@ -36,7 +36,9 @@ public final class Drawing {
 		}
 
 		GC gc = new GC();
-		gc.innerGC = new SkijaGC(originalNativeGC, onlyForMeasuring);
+		gc.innerGC = onlyForMeasuring
+				? SkijaGC.createMeasureInstance(originalNativeGC)
+				: SkijaGC.createDefaultInstance(originalNativeGC);
 		return gc;
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -26,6 +26,15 @@ import io.github.humbleui.skija.Font;
 import io.github.humbleui.types.*;
 
 public class SkijaGC extends GCHandle {
+
+	public static SkijaGC createDefaultInstance(NativeGC gc) {
+		return new SkijaGC(gc, false);
+	}
+
+	public static SkijaGC createMeasureInstance(NativeGC gc) {
+		return new SkijaGC(gc, true);
+	}
+
 	private final Surface surface;
 
 	private NativeGC innerGC;
@@ -38,7 +47,7 @@ public class SkijaGC extends GCHandle {
 
 	private static Map<ColorType, int[]> colorTypeMap = null;
 
-	public SkijaGC(NativeGC gc, boolean onlyForMeasuring) {
+	private SkijaGC(NativeGC gc, boolean onlyForMeasuring) {
 		innerGC = gc;
 		originalDrawingSize = extractSize(innerGC.drawable);
 		if (onlyForMeasuring) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -38,12 +38,15 @@ public class SkijaGC extends GCHandle {
 
 	private static Map<ColorType, int[]> colorTypeMap = null;
 
-	public SkijaGC(NativeGC gc, Color backgroundColor) {
+	public SkijaGC(NativeGC gc, boolean onlyForMeasuring) {
 		innerGC = gc;
 		originalDrawingSize = extractSize(innerGC.drawable);
-		if (backgroundColor == null)
-			backgroundColor = extractBackgroundColor(gc, originalDrawingSize);
-		surface = createSurface(backgroundColor);
+		if (onlyForMeasuring) {
+			surface = createMeasureSurface();
+		} else {
+			Color backgroundColor = extractBackgroundColor(gc, originalDrawingSize);
+			surface = createSurface(backgroundColor);
+		}
 		initFont();
 	}
 
@@ -100,6 +103,11 @@ public class SkijaGC extends GCHandle {
 			surface.getCanvas().clear(convertSWTColorToSkijaColor(backgroundColor));
 		}
 		return surface;
+	}
+
+	private Surface createMeasureSurface() {
+		return Surface.makeRaster(ImageInfo.makeN32Premul(1, 1), 0,
+				new SurfaceProps(PixelGeometry.RGB_H));
 	}
 
 	private void initFont() {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
@@ -614,10 +614,7 @@ public class Button extends CustomControl {
 			boxSpace = BOX_SIZE + SPACING;
 		}
 		if (text != null && !text.isEmpty()) {
-			Point textExtent = Drawing.executeOnGC(this, gc -> {
-				gc.setFont(getFont());
-				return gc.textExtent(text, DRAW_FLAGS);
-			});
+			Point textExtent = Drawing.getTextExtent(this, text, DRAW_FLAGS);
 			textWidth = textExtent.x + 1;
 			textHeight = textExtent.y;
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
@@ -187,10 +187,7 @@ public class Label extends CustomControl {
 		int topMargin = this.topMargin;
 
 		if (text != null && !text.isEmpty()) {
-			Point textExtent = Drawing.executeOnGC(this, gc -> {
-				gc.setFont(getFont());
-				return gc.textExtent(text, DRAW_FLAGS);
-			});
+			Point textExtent = Drawing.getTextExtent(this, text, DRAW_FLAGS);
 			lineWidth = textExtent.x;
 			lineHeight = textExtent.y;
 			if (image != null) {


### PR DESCRIPTION
This should improve the performance by avoiding to determine the background color and allocating a large bitmap.