### PR TITLE
Implement proper double-buffering for custom widgets

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaDrawingAPITest.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SkijaDrawingAPITest.java
@@ -29,7 +29,7 @@ public class SkijaDrawingAPITest {
 		SWT.USE_SKIJA = true;
 
 		shell.addPaintListener(event -> {
-			GC skijaGC = Drawing.createGraphicsContext(event.gc);
+			GC skijaGC = Drawing.createGraphicsContext(event.gc, shell);
 			skijaGC.setBackground(display.getSystemColor(SWT.COLOR_GREEN));
 
 			skijaGC.drawString("yTjJ", 0, 0, false);

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Widget.java
@@ -49,8 +49,7 @@ import org.eclipse.swt.internal.cocoa.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  */
 public abstract class Widget {
-	public int style;
-	int state;
+	int style, state;
 	Display display;
 	protected EventTable eventTable;
 	Object data;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -28,11 +28,15 @@ import io.github.humbleui.types.*;
 public class SkijaGC extends GCHandle {
 
 	public static SkijaGC createDefaultInstance(NativeGC gc) {
-		return new SkijaGC(gc, false);
+		return new SkijaGC(gc, gc.drawable, false);
 	}
 
-	public static SkijaGC createMeasureInstance(NativeGC gc) {
-		return new SkijaGC(gc, true);
+	public static SkijaGC createDefaultInstance(NativeGC gc, Control control) {
+		return new SkijaGC(gc, control, false);
+	}
+
+	public static SkijaGC createMeasureInstance(NativeGC gc, Control control) {
+		return new SkijaGC(gc, control, true);
 	}
 
 	private final Surface surface;
@@ -47,9 +51,9 @@ public class SkijaGC extends GCHandle {
 
 	private static Map<ColorType, int[]> colorTypeMap = null;
 
-	private SkijaGC(NativeGC gc, boolean onlyForMeasuring) {
+	private SkijaGC(NativeGC gc, Drawable drawable, boolean onlyForMeasuring) {
 		innerGC = gc;
-		originalDrawingSize = extractSize(innerGC.drawable);
+		originalDrawingSize = extractSize(drawable);
 		if (onlyForMeasuring) {
 			surface = createMeasureSurface();
 		} else {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
@@ -138,6 +138,7 @@ public class Button extends CustomControl {
 	 */
 	public Button(Composite parent, int style) {
 		super(parent, checkStyle(style));
+		this.style |= SWT.DOUBLE_BUFFERED;
 
 		Listener listener = event -> {
 			switch (event.type) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
@@ -133,6 +133,7 @@ public class Label extends CustomControl {
 	 */
 	public Label(Composite parent, int style) {
 		super(parent, checkStyle(style));
+		this.style |= SWT.DOUBLE_BUFFERED;
 		if ((style & (SWT.CENTER | SWT.RIGHT)) == 0) {
 			style |= SWT.LEFT;
 		}
@@ -176,6 +177,7 @@ public class Label extends CustomControl {
 		return false;
 	}
 
+	@Override
 	protected Point computeDefaultSize() {
 		int lineWidth = 0;
 		int lineHeight = 0;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Link.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Link.java
@@ -113,6 +113,7 @@ public class Link extends CustomControl {
 	 */
 	public Link(Composite parent, int style) {
 		super(parent, checkStyle(style));
+		this.style |= SWT.DOUBLE_BUFFERED;
 		if ((style & (SWT.CENTER | SWT.RIGHT)) == 0) {
 			style |= SWT.LEFT;
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Scale.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Scale.java
@@ -144,6 +144,7 @@ public class Scale extends CustomControl {
 	 */
 	public Scale(Composite parent, int style) {
 		super(parent, checkStyle(style));
+		this.style |= SWT.DOUBLE_BUFFERED;
 
 		Listener listener = event -> {
 			switch (event.type) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolBar.java
@@ -148,6 +148,8 @@ public class ToolBar extends Composite {
 	 */
 	public ToolBar(Composite parent, int style, boolean internal) {
 		super(parent, checkStyle(style));
+		this.style |= SWT.DOUBLE_BUFFERED;
+
 		renderer = new ToolBarRenderer(this);
 
 		listener = event -> {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/toolbar/ToolBarRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/toolbar/ToolBarRenderer.java
@@ -14,14 +14,13 @@
 package org.eclipse.swt.widgets.toolbar;
 
 import java.util.*;
+import java.util.List;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.widgets.*;
 import org.eclipse.swt.widgets.ToolBar.*;
 import org.eclipse.swt.widgets.toolbar.ToolBarLayout.*;
-
-import java.util.List;
 
 /**
  * Default renderer for the ToolBar.
@@ -46,8 +45,6 @@ public class ToolBarRenderer implements IToolBarRenderer {
 	}
 
 	private void render(GC gc, Point size, List<Row> rows) {
-		gc.fillRectangle(0, 0, size.x, size.y);
-
 		if (bar.isShadowOut()) {
 			gc.setForeground(new Color(160, 160, 160));
 			gc.drawLine(0, 0, size.x, 0);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Widget.java
@@ -65,8 +65,7 @@ public abstract class Widget {
 	 * @noreference This field is not intended to be referenced by clients.
 	 */
 	public long handle;
-	public int style;
-	int state;
+	int style, state;
 	Display display;
 	protected EventTable eventTable;
 	Object data;

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Widget.java
@@ -65,8 +65,7 @@ public abstract class Widget {
 	 * @noreference This field is not intended to be referenced by clients.
 	 */
 	public int nativeZoom;
-	public int style;
-	int state;
+	int style, state;
 	Display display;
 	protected EventTable eventTable;
 	Object data;


### PR DESCRIPTION
Currently, the rendering of custom widgets relies on custom implemented double buffering using an additional image to be painted in. This requires changes to the widget style (no background) and produces significant performance overhead.

With this change, native double buffering is used to render custom widgets. To this end, the SWT.DOUBLE_BUFFERING is properly set for the controls. The custom double buffering logic is removed from the Drawing class and previously necessary visibility changes to the style field of Widgets are reverted. Since the native GC used for double buffering does not refer to a drawable anymore, it has to be passed to the SkijaGC to extract bounds information from.

This PR is based on and should be merged after:
- #131