### PR TITLE
Custom controls: make transparent

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Drawing.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Drawing.java
@@ -54,11 +54,6 @@ public final class Drawing {
 	 */
 	public static void drawWithGC(Control control, GC originalGC, Consumer<GC> drawOperation) {
 		Rectangle bounds = control.getBounds();
-		if (originalGC != null && originalGC.innerGC instanceof NativeGC nativeGC) {
-			if (nativeGC.drawable != control) {
-				throw new IllegalStateException("given GC was not created for given control");
-			}
-		}
 
 		if (originalGC == null) {
 			originalGC = new GC(control);
@@ -78,7 +73,6 @@ public final class Drawing {
 			if (widgetBackground == null) {
 				extractAndStoreBackgroundColor(bounds, originalGC);
 			}
-			control.style |= SWT.NO_BACKGROUND;
 		}
 
 		if (gc.innerGC instanceof NativeGC) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
@@ -684,6 +684,7 @@ public class Button extends CustomControl {
 	}
 
 	static int checkStyle(int style) {
+		style |= SWT.TRANSPARENT;
 		style = checkBits(style, SWT.PUSH, SWT.ARROW, SWT.CHECK, SWT.RADIO,
 				SWT.TOGGLE, COMMAND_LINK ? SWT.COMMAND : 0);
 		if ((style & (SWT.PUSH | SWT.TOGGLE)) != 0) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/CSimpleText.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/CSimpleText.java
@@ -497,8 +497,13 @@ public class CSimpleText extends NativeBasedCustomScrollable {
 
 	private void drawBackground(Event e) {
 		GC gc = e.gc;
-		gc.fillRectangle(e.x, e.y, e.width - 1, e.height - 1);
-		if ((style & SWT.BORDER) != 0 && getEditable() && isEnabled()) {
+		int height = e.height;
+		final boolean drawLine = (style & SWT.BORDER) != 0 && getEditable() && isEnabled();
+		if (drawLine) {
+			height--;
+		}
+		gc.fillRectangle(e.x, e.y, e.width, height);
+		if (drawLine) {
 			Color foreground = gc.getForeground();
 			gc.setForeground(BORDER_COLOR);
 			gc.drawLine(e.x, e.y + e.height - 1, e.x + e.x + e.width - 1, e.y + e.height - 1);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
@@ -171,8 +171,9 @@ public class Label extends CustomControl {
 		}
 		int mask = SWT.SHADOW_IN | SWT.SHADOW_OUT | SWT.SHADOW_NONE
 				| SWT.LEFT_TO_RIGHT | SWT.RIGHT_TO_LEFT;
-		style = style & mask;
-		style |= SWT.NO_FOCUS | SWT.DOUBLE_BUFFERED;
+		style &= mask;
+		style |= SWT.NO_FOCUS;
+		style |= SWT.TRANSPARENT;
 		return style;
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Scale.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Scale.java
@@ -190,6 +190,7 @@ public class Scale extends CustomControl {
 			style &= ~SWT.RIGHT_TO_LEFT;
 		}
 
+		style |= SWT.TRANSPARENT;
 		return style;
 	}
 


### PR DESCRIPTION
fixes bug #139: Minimizing & restoring shell causes the background color of custom drawn widgets being black
