### PR TITLE
Proper SkijaGC disposal and initialization of device

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Drawing.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Drawing.java
@@ -77,7 +77,6 @@ public final class Drawing {
 			gc.commit();
 		} finally {
 			gc.dispose();
-			originalGC.dispose();
 		}
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -53,6 +53,7 @@ public class SkijaGC extends GCHandle {
 
 	private SkijaGC(NativeGC gc, Drawable drawable, boolean onlyForMeasuring) {
 		innerGC = gc;
+		device = gc.device;
 		originalDrawingSize = extractSize(drawable);
 		if (onlyForMeasuring) {
 			surface = createMeasureSurface();
@@ -125,7 +126,9 @@ public class SkijaGC extends GCHandle {
 
 	@Override
 	public void dispose() {
-		this.innerGC.dispose();
+		surface.close();
+		innerGC = null;
+		font = null;
 	}
 
 	@Override
@@ -207,7 +210,6 @@ public class SkijaGC extends GCHandle {
 		innerGC.drawImage(transferImage, 0, 0, drawingSizeInPixels.x, drawingSizeInPixels.y, //
 				0, 0, originalDrawingSize.x, originalDrawingSize.y);
 		transferImage.dispose();
-		surface.close();
 	}
 
 	@Override
@@ -1174,8 +1176,7 @@ public class SkijaGC extends GCHandle {
 
 	@Override
 	public boolean isDisposed() {
-		System.err.println("WARN: Not implemented yet: " + new Throwable().getStackTrace()[0]);
-		return false;
+		return surface.isClosed();
 	}
 
 	static PaletteData getPaletteData(ColorType colorType) {


### PR DESCRIPTION
SkijaGC does currently not initialize it's device, i.e., a call to SkijaGC#getDevice() always yields null. In addition, disposal handling of SkijaGC is broken as it always disposes the underlying native GC even if that is still supposed to be used and the the surface of the SkijaGC is already disposed at commit instead of upon disposal. These issues are addressed by this change.