### PR TITLE
Make Text widget use SkijaGC if enabled

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Drawing.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Drawing.java
@@ -61,8 +61,10 @@ public final class Drawing {
 			}
 		}
 
+		boolean usingTemporaryGC = false;
 		if (originalGC == null) {
 			originalGC = new GC(control);
+			usingTemporaryGC = true;
 		}
 		originalGC.setFont(control.getFont());
 		originalGC.setForeground(control.getForeground());
@@ -77,6 +79,9 @@ public final class Drawing {
 			gc.commit();
 		} finally {
 			gc.dispose();
+			if (usingTemporaryGC) {
+				originalGC.dispose();
+			}
 		}
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -524,12 +524,12 @@ public class SkijaGC extends GCHandle {
 
 	@Override
 	public void drawText(String string, int x, int y) {
-		drawText(string, x, y, SWT.NONE);
+		drawText(string, x, y, false);
 	}
 
 	@Override
 	public void drawText(String string, int x, int y, boolean isTransparent) {
-		drawText(string, x, y, SWT.TRANSPARENT);
+		drawText(string, x, y, isTransparent ? SWT.TRANSPARENT : SWT.NONE);
 	}
 
 	@Override
@@ -537,11 +537,17 @@ public class SkijaGC extends GCHandle {
 		if (text == null) {
 			return;
 		}
-		performDrawText(paint -> {
-			TextBlob textBlob = buildTextBlob(text);
-			Point point = calculateSymbolCenterPoint(x, y);
-			surface.getCanvas().drawTextBlob(textBlob, point.x, point.y, paint);
-		});
+		TextBlob textBlob = buildTextBlob(text);
+		if (textBlob == null) {
+			return;
+		}
+		if ((flags & (SWT.TRANSPARENT | SWT.DRAW_TRANSPARENT)) == 0) {
+			int textWidth = (int) textBlob.getBounds().getWidth();
+			int fontHeight = (int) font.getMetrics().getHeight();
+			fillRectangle(x, y, textWidth, fontHeight);
+		}
+		Point point = calculateSymbolCenterPoint(x, y);
+		performDrawText(paint -> surface.getCanvas().drawTextBlob(textBlob, point.x, point.y, paint));
 	}
 
 	// y position in drawTextBlob() is the text baseline, e.g., the bottom of "T"

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/CTextCaret.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/CTextCaret.java
@@ -633,9 +633,8 @@ public class CTextCaret extends Widget {
 		return drawCaret();
 	}
 
-	public void paint(Event e) {
+	public void paint(GC gc) {
 		if (isShowing) {
-			GC gc = e.gc;
 			Color oldBackground = gc.getBackground();
 			gc.setBackground(parent.getForeground());
 			gc.fillRectangle(getBounds());


### PR DESCRIPTION
Currently, the Text widget based on CSimpleText uses the original (native) GC. With this change, it performs rendering based on a SkijaGC if enabled.

To this end, the PR also adds proper handling for the transparency flag when drawing text with SkijaGC. The transparency flag and argument of SkijaGCs drawText methods have not been considered. With this change, the background of the text is drawn if the transparent flag is not set as defined by the API.