### PR TITLE
Use Drawable and Control instead of CustomControl in some methods

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -34,12 +34,12 @@ public class SkijaGC extends GCHandle {
 		return new SkijaGC(gc, gc.drawable, false);
 	}
 
-	public static SkijaGC createDefaultInstance(NativeGC gc, Control control) {
-		return new SkijaGC(gc, control, false);
+	public static SkijaGC createDefaultInstance(NativeGC gc, Drawable drawable) {
+		return new SkijaGC(gc, drawable, false);
 	}
 
-	public static SkijaGC createMeasureInstance(NativeGC gc, Control control) {
-		return new SkijaGC(gc, control, true);
+	public static SkijaGC createMeasureInstance(NativeGC gc, Drawable drawable) {
+		return new SkijaGC(gc, drawable, true);
 	}
 
 	private final Surface surface;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ControlRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ControlRenderer.java
@@ -24,9 +24,9 @@ public abstract class ControlRenderer {
 
 	protected abstract void paint(GC gc, int width, int height);
 
-	private final CustomControl control;
+	private final Control control;
 
-	protected ControlRenderer(CustomControl control) {
+	protected ControlRenderer(Control control) {
 		this.control = control;
 	}
 


### PR DESCRIPTION
The objective is to reduce constraints and be able to use the methods more widely.