### PR TITLE
Prepare Renderer classes for Composites

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Drawing.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/Drawing.java
@@ -107,7 +107,7 @@ public final class Drawing {
 		}
 	}
 
-	public static Point getTextExtent(CustomControl control, String text, int drawFlags) {
+	public static Point getTextExtent(Control control, String text, int drawFlags) {
 		return measure(control, gc -> {
 			gc.setFont(control.getFont());
 			return gc.textExtent(text, drawFlags);
@@ -123,7 +123,7 @@ public final class Drawing {
 	 * @param operation the operation to execute
 	 * @return the result of the given operation
 	 */
-	public static <T> T measure(CustomControl control, Function<GC, T> operation) {
+	public static <T> T measure(Control control, Function<GC, T> operation) {
 		GC originalGC = new GC(control);
 		GC gc = createGraphicsContext(originalGC, control, true);
 		try {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ButtonRenderer.java
@@ -20,6 +20,8 @@ public abstract class ButtonRenderer extends ControlRenderer {
 
 	private final Button button;
 
+	public abstract Point computeDefaultSize();
+
 	private Image disabledImage;
 	private boolean pressed;
 	private boolean hover;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ControlRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ControlRenderer.java
@@ -24,9 +24,9 @@ public abstract class ControlRenderer {
 
 	protected abstract void paint(GC gc, int width, int height);
 
-	private final CustomControl control;
+	private final Control control;
 
-	protected ControlRenderer(CustomControl control) {
+	protected ControlRenderer(Control control) {
 		this.control = control;
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ControlRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ControlRenderer.java
@@ -20,8 +20,6 @@ import java.util.function.Function;
 
 public abstract class ControlRenderer {
 
-	public abstract Point computeDefaultSize();
-
 	protected abstract void paint(GC gc, int width, int height);
 
 	private final Control control;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LabelRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LabelRenderer.java
@@ -18,6 +18,8 @@ import org.eclipse.swt.graphics.*;
 
 public abstract class LabelRenderer extends ControlRenderer {
 
+	public abstract Point computeDefaultSize();
+
 	/** a string inserted in the middle of text that has been shortened */
 	private static final String ELLIPSIS = "..."; //$NON-NLS-1$ // could use
 	// the ellipsis glyph on

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ScaleRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ScaleRenderer.java
@@ -19,6 +19,9 @@ import org.eclipse.swt.graphics.*;
  * Interface for all scale renderer
  */
 public abstract class ScaleRenderer extends ControlRenderer {
+
+	public abstract Point computeDefaultSize();
+
 	/**
 	 * Maps the point to a scale value
 	 *


### PR DESCRIPTION
ControlRenderer became generic to avoid casting or control specific fields in subclasses