### PR TITLE
Feature/fontmetrics scaling bug

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaFontMetrics.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaFontMetrics.java
@@ -28,27 +28,27 @@ public class SkijaFontMetrics extends FontMetricsHandle {
 	@Override
 	public int getAscent() {
 		// in skija, these are negative usually.
-		return Math.abs(Math.round(DPIUtil.autoScaleDown(metrics.getAscent())));
+		return Math.abs(DPIUtil.autoScaleDownToInt(metrics.getAscent()));
 	}
 
 	@Override
 	public int getDescent() {
-		return Math.round(DPIUtil.autoScaleDown(metrics.getDescent()));
+		return DPIUtil.autoScaleDownToInt(metrics.getDescent());
 	}
 
 	@Override
 	public int getHeight() {
-		return Math.round(DPIUtil.autoScaleDown(metrics.getHeight()));
+		return DPIUtil.autoScaleDownToInt(metrics.getHeight());
 	}
 
 	@Override
 	public int getLeading() {
-		return Math.round(DPIUtil.autoScaleDown(metrics.getLeading()));
+		return DPIUtil.autoScaleDownToInt(metrics.getLeading());
 	}
 
 	@Override
 	public int getAverageCharWidth() {
-		return Math.round(DPIUtil.autoScaleDown(metrics.getAvgCharWidth()));
+		return DPIUtil.autoScaleDownToInt(metrics.getAvgCharWidth());
 	}
 
 	@Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaFontMetrics.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaFontMetrics.java
@@ -19,7 +19,7 @@ import org.eclipse.swt.internal.*;
 
 public class SkijaFontMetrics extends FontMetricsHandle {
 
-	private io.github.humbleui.skija.FontMetrics metrics;
+	private final io.github.humbleui.skija.FontMetrics metrics;
 
 	SkijaFontMetrics(io.github.humbleui.skija.FontMetrics metrics) {
 		this.metrics = metrics;
@@ -58,20 +58,21 @@ public class SkijaFontMetrics extends FontMetricsHandle {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		}
+		if (obj == null) {
 			return false;
-		if (getClass() != obj.getClass())
+		}
+		if (getClass() != obj.getClass()) {
 			return false;
+		}
 		SkijaFontMetrics other = (SkijaFontMetrics) obj;
 		return Objects.equals(metrics, other.metrics);
 	}
 
 	@Override
 	public double getAverageCharacterWidth() {
-		return this.metrics.getAvgCharWidth();
-
+		return metrics.getAvgCharWidth();
 	}
-
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaFontMetrics.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaFontMetrics.java
@@ -28,27 +28,27 @@ public class SkijaFontMetrics extends FontMetricsHandle {
 	@Override
 	public int getAscent() {
 		// in skija, these are negative usually.
-		return Math.abs((int) this.metrics.getAscent());
+		return Math.abs(Math.round(DPIUtil.autoScaleDown(metrics.getAscent())));
 	}
 
 	@Override
 	public int getDescent() {
-		return (int) this.metrics.getDescent();
+		return Math.round(DPIUtil.autoScaleDown(metrics.getDescent()));
 	}
 
 	@Override
 	public int getHeight() {
-		return (int) this.metrics.getHeight();
+		return Math.round(DPIUtil.autoScaleDown(metrics.getHeight()));
 	}
 
 	@Override
 	public int getLeading() {
-		return (int) this.metrics.getLeading();
+		return Math.round(DPIUtil.autoScaleDown(metrics.getLeading()));
 	}
 
 	@Override
 	public int getAverageCharWidth() {
-		return (int) this.metrics.getAvgCharWidth();
+		return Math.round(DPIUtil.autoScaleDown(metrics.getAvgCharWidth()));
 	}
 
 	@Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -792,7 +792,7 @@ public class SkijaGC extends GCHandle {
 	public Point textExtent(String string, int flags) {
 		float height = font.getMetrics().getHeight();
 		float width = font.measureTextWidth(replaceMnemonics(string));
-		return new Point(Math.round(DPIUtil.autoScaleDown(width)), Math.round(DPIUtil.autoScaleDown(height)));
+		return new Point(DPIUtil.autoScaleDownToInt(width), DPIUtil.autoScaleDownToInt(height));
 	}
 
 	@Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -792,7 +792,7 @@ public class SkijaGC extends GCHandle {
 	public Point textExtent(String string, int flags) {
 		float height = font.getMetrics().getHeight();
 		float width = font.measureTextWidth(replaceMnemonics(string));
-		return new Point((int) DPIUtil.autoScaleDown(width), (int) DPIUtil.autoScaleDown(height));
+		return new Point(Math.round(DPIUtil.autoScaleDown(width)), Math.round(DPIUtil.autoScaleDown(height)));
 	}
 
 	@Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/internal/DPIUtil.java
@@ -200,6 +200,10 @@ public static float scaleDown(float size, int zoom) {
 	return (size / scaleFactor);
 }
 
+public static int autoScaleDownToInt(float value) {
+	return Math.round(DPIUtil.autoScaleDown(value));
+}
+
 /**
  * Auto-scale down float dimensions if enabled for Drawable class.
  */


### PR DESCRIPTION
On a 200% zoom monitor, the `LinkExample` optically showed two line breaks where only one was there.