### PR TITLE
Text: fixing some bugs

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -542,9 +542,11 @@ public class SkijaGC extends GCHandle {
 			return;
 		}
 		if ((flags & (SWT.TRANSPARENT | SWT.DRAW_TRANSPARENT)) == 0) {
-			int textWidth = (int) textBlob.getBounds().getWidth();
-			int fontHeight = (int) font.getMetrics().getHeight();
-			fillRectangle(x, y, textWidth, fontHeight);
+			int textWidth = Math.round(textBlob.getBounds().getWidth());
+			int fontHeight = Math.round(font.getMetrics().getHeight());
+			performDrawFilled(
+					paint -> surface.getCanvas().drawRect(new Rect(DPIUtil.autoScaleUp(x), DPIUtil.autoScaleUp(y),
+							DPIUtil.autoScaleUp(x) + textWidth, DPIUtil.autoScaleUp(y) + fontHeight), paint));
 		}
 		Point point = calculateSymbolCenterPoint(x, y);
 		performDrawText(paint -> surface.getCanvas().drawTextBlob(textBlob, point.x, point.y, paint));

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Text.java
@@ -188,6 +188,7 @@ public class Text extends NativeBasedCustomScrollable {
 			case SWT.MouseUp -> Text.this.onMouseUp(event);
 			case SWT.MouseWheel -> Text.this.onMouseWheel(event);
 			case SWT.KeyDown -> Text.this.keyPressed(event);
+			case SWT.Traverse -> Text.this.onTraverse(event);
 			case SWT.FocusIn -> Text.this.focusGained(event);
 			case SWT.FocusOut -> Text.this.focusLost(event);
 			case SWT.Gesture -> Text.this.onGesture(event);
@@ -200,6 +201,7 @@ public class Text extends NativeBasedCustomScrollable {
 		addListener(SWT.MouseUp, listener);
 		addListener(SWT.MouseWheel, listener);
 		addListener(SWT.KeyDown, listener);
+		addListener(SWT.Traverse, listener);
 		addListener(SWT.FocusIn, listener);
 		addListener(SWT.FocusOut, listener);
 		addListener(SWT.Gesture, listener);
@@ -419,6 +421,17 @@ public class Text extends NativeBasedCustomScrollable {
 				model.insert(e.character);
 			}
 		}
+		}
+	}
+
+	private void onTraverse(Event e) {
+		switch (e.detail) {
+		case SWT.TRAVERSE_TAB_NEXT -> {
+			if ((style & SWT.MULTI) == 0 || (e.stateMask & SWT.MODIFIER_MASK) == 0) {
+				e.doit = false;
+			}
+		}
+		default -> e.doit = false;
 		}
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Text.java
@@ -446,24 +446,31 @@ public class Text extends NativeBasedCustomScrollable {
 
 		GC gc = new GC(this);
 		String[] textLines = model.getLines();
-		int clickedLine = Math.min(Math.round(y / getLineHeight(gc)), textLines.length - 1);
+		int clickedLine = Math.min(y / getLineHeight(gc), textLines.length - 1);
 		int selectedLine = Math.min(clickedLine, textLines.length - 1);
-		String text = "";
-		if (clickedLine > selectedLine) {
-			text = textLines[selectedLine];
-		} else {
-			text = textLines[selectedLine];
-			for (int i = 0; i < text.length(); i++) {
-				Point textLocationPixel = getLocationByTextLocation(new TextLocation(selectedLine, i), gc);
+		String text = textLines[selectedLine];
+		if (clickedLine == selectedLine && text.length() > 0) {
+			int before = 0;
+			int after = text.length();
+			while (true) {
+				int middle = (before + after) / 2;
+				final int middleX = getLocationByTextLocation(new TextLocation(selectedLine, middle), gc).x;
+				if (middleX > x) {
+					after = middle;
+					continue;
+				}
 
-				if (textLocationPixel.x >= x + 5) {
-					if (i > 0) {
-						text = text.substring(0, i - 1);
-					} else {
-						text = "";
+				if (after - middle == 1) {
+					final int afterX = getLocationByTextLocation(new TextLocation(selectedLine, after), gc).x;
+					if (afterX - x < x - middleX) {
+						text = text.substring(0, after);
+					}
+					else {
+						text = text.substring(0, middle);
 					}
 					break;
 				}
+				before = middle;
 			}
 		}
 		gc.dispose();


### PR DESCRIPTION
- pressing cursor keys did not move the caret, but focused the next/prev control
- clicking at certain positions, e.g. before a narrow character, did not allow to set the caret at this location
- the selected text background was drawn too far right on a 200% zoom display