### PR TITLE
Use configured background and foreground color

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/BasicLabelRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/BasicLabelRenderer.java
@@ -19,6 +19,8 @@ import org.eclipse.swt.graphics.*;
 
 public class BasicLabelRenderer extends LabelRenderer {
 
+	private static final Color BACKGROUND_COLOR = new Color(240, 240, 240);
+	private static final Color FOREGROUND_COLOR = new Color(0, 0, 0);
 	private static final Color DISABLED_COLOR = new Color(160, 160, 160);
 	private static final Color SHADOW_IN_COLOR1 = new Color(160, 160, 160);
 	private static final Color SHADOW_IN_COLOR2 = new Color(255, 255, 255);
@@ -69,6 +71,16 @@ public class BasicLabelRenderer extends LabelRenderer {
 					 + getBottomMargin();
 
 		return new Point(width, height);
+	}
+
+	@Override
+	public Color getDefaultBackground() {
+		return BACKGROUND_COLOR;
+	}
+
+	@Override
+	public Color getDefaultForeground() {
+		return FOREGROUND_COLOR;
 	}
 
 	@Override
@@ -266,7 +278,7 @@ public class BasicLabelRenderer extends LabelRenderer {
 		}
 
 		if (lines != null) {
-			gc.setForeground(isEnabled() ? getForeground() : DISABLED_COLOR);
+			gc.setForeground(isEnabled() ? label.getForeground() : DISABLED_COLOR);
 			for (String line : lines) {
 				int lineX = x;
 				if (lines.length > 1) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
@@ -158,6 +158,11 @@ public class Button extends CustomControl {
 		initializeAccessible();
 	}
 
+	@Override
+	protected ControlRenderer getRenderer() {
+		return renderer;
+	}
+
 	/**
 	 * TODO: improve this support and make it completely similar to native
 	 * windows buttons.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ButtonRenderer.java
@@ -18,7 +18,7 @@ import org.eclipse.swt.graphics.*;
 
 public abstract class ButtonRenderer extends ControlRenderer {
 
-	private final Button button;
+	protected final Button button;
 
 	public abstract Point computeDefaultSize();
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ControlRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ControlRenderer.java
@@ -22,6 +22,10 @@ public abstract class ControlRenderer {
 
 	protected abstract void paint(GC gc, int width, int height);
 
+	public abstract Color getDefaultBackground();
+
+	public abstract Color getDefaultForeground();
+
 	private final Control control;
 
 	protected ControlRenderer(Control control) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/CustomControl.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/CustomControl.java
@@ -14,8 +14,7 @@
 package org.eclipse.swt.widgets;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.graphics.*;
 
 /**
  * Temporary API.
@@ -24,10 +23,14 @@ public abstract class CustomControl extends NativeBasedCustomControl {
 
 	protected abstract Point computeDefaultSize();
 
+	protected abstract ControlRenderer getRenderer();
+
 	private int x;
 	private int y;
 	private int width;
 	private int height;
+	protected Color background;
+	protected Color foreground;
 
 	protected CustomControl(Composite parent, int style) {
 		super(parent, style);
@@ -120,6 +123,30 @@ public abstract class CustomControl extends NativeBasedCustomControl {
 		if (parent.isEnabled()) {
 			redraw();
 		}
+	}
+
+	@Override
+	public final Color getBackground() {
+		return background != null ? background : getRenderer().getDefaultBackground();
+	}
+
+	@Override
+	public void setBackground(Color color) {
+		if (color != null && color.isDisposed ()) error (SWT.ERROR_INVALID_ARGUMENT);
+		this.background = color;
+		super.setBackground(color);
+	}
+
+	@Override
+	public final Color getForeground() {
+		return foreground != null ? foreground : getRenderer().getDefaultForeground();
+	}
+
+	@Override
+	public void setForeground(Color color) {
+		if (color != null && color.isDisposed ()) error (SWT.ERROR_INVALID_ARGUMENT);
+		this.foreground = color;
+		super.setForeground(color);
 	}
 
 	@Override

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultArrowButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultArrowButtonRenderer.java
@@ -19,8 +19,9 @@ import org.eclipse.swt.graphics.*;
 
 public class DefaultArrowButtonRenderer extends ButtonRenderer {
 
+	private static final Color BACKGROUND_COLOR = new Color(240, 240, 240);
+	private static final Color FOREGROUND_COLOR = new Color(0, 0, 0);
 	private static final Color DISABLED_COLOR = new Color(160, 160, 160);
-	private static final Color TEXT_COLOR = new Color(0, 0, 0);
 
 	public DefaultArrowButtonRenderer(Button button) {
 		super(button);
@@ -38,9 +39,8 @@ public class DefaultArrowButtonRenderer extends ButtonRenderer {
 		if (hasFocus()) {
 			gc.drawFocus(3, 3, width - 7, height - 7);
 		}
-		Color bg2 = gc.getBackground();
 
-		gc.setBackground(isEnabled() ? TEXT_COLOR : DISABLED_COLOR);
+		gc.setBackground(isEnabled() ? FOREGROUND_COLOR : DISABLED_COLOR);
 
 		int centerHeight = height / 2;
 		int centerWidth = width / 2;
@@ -77,6 +77,15 @@ public class DefaultArrowButtonRenderer extends ButtonRenderer {
 		}
 
 		gc.fillPolygon(curve);
-		gc.setBackground(bg2);
+	}
+
+	@Override
+	public Color getDefaultBackground() {
+		return BACKGROUND_COLOR;
+	}
+
+	@Override
+	public Color getDefaultForeground() {
+		return FOREGROUND_COLOR;
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultButtonRenderer.java
@@ -19,14 +19,14 @@ import org.eclipse.swt.graphics.*;
 
 public class DefaultButtonRenderer extends ButtonRenderer {
 
+	private static final Color BACKGROUND_COLOR = new Color(255, 255, 255);
+	private static final Color FOREGROUND_COLOR = new Color(0, 0, 0);
 	private static final Color HOVER_COLOR = new Color(224, 238, 254);
 	private static final Color TOGGLE_COLOR = new Color(204, 228, 247);
 	private static final Color SELECTION_COLOR = new Color(0, 95, 184);
-	private static final Color TEXT_COLOR = new Color(0, 0, 0);
 	private static final Color DISABLED_COLOR = new Color(160, 160, 160);
 	private static final Color BORDER_COLOR = new Color(160, 160, 160);
 	private static final Color BORDER_DISABLED_COLOR = new Color(192, 192, 192);
-	private static final Color PUSH_BACKGROUND_COLOR = new Color(255, 255, 255);
 
 	/**
 	 * Left and right margins
@@ -140,7 +140,7 @@ public class DefaultButtonRenderer extends ButtonRenderer {
 
 		// Draw text
 		if (text != null && !text.isEmpty()) {
-			gc.setForeground(isEnabled() ? TEXT_COLOR : DISABLED_COLOR);
+			gc.setForeground(isEnabled() ? button.getForeground() : DISABLED_COLOR);
 			int textTopOffset = (height - 1 - textHeight) / 2;
 			int textLeftOffset = contentArea.x + imageSpace;
 			if (shiftDownRight) {
@@ -155,6 +155,16 @@ public class DefaultButtonRenderer extends ButtonRenderer {
 		}
 	}
 
+	@Override
+	public Color getDefaultBackground() {
+		return BACKGROUND_COLOR;
+	}
+
+	@Override
+	public Color getDefaultForeground() {
+		return FOREGROUND_COLOR;
+	}
+
 	private void drawPushButton(GC gc, int w, int h) {
 		final boolean isToggle = (getStyle() & SWT.TOGGLE) != 0;
 		if (isEnabled()) {
@@ -165,7 +175,7 @@ public class DefaultButtonRenderer extends ButtonRenderer {
 			} else if (isHover()) {
 				gc.setBackground(HOVER_COLOR);
 			} else {
-				gc.setBackground(PUSH_BACKGROUND_COLOR);
+				gc.setBackground(button.getBackground());
 			}
 			gc.fillRoundRectangle(0, 0, w, h, 6, 6);
 		}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultCheckboxRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultCheckboxRenderer.java
@@ -19,9 +19,10 @@ import org.eclipse.swt.graphics.*;
 
 public class DefaultCheckboxRenderer extends ButtonRenderer {
 
+	private static final Color BACKGROUND_COLOR = new Color(240, 240, 240);
+	private static final Color FOREGROUND_COLOR = new Color(0, 0, 0);
 	private static final Color HOVER_COLOR = new Color(224, 238, 254);
 	private static final Color SELECTION_COLOR = new Color(0, 95, 184);
-	private static final Color TEXT_COLOR = new Color(0, 0, 0);
 	private static final Color DISABLED_COLOR = new Color(160, 160, 160);
 	private static final Color BORDER_DISABLED_COLOR = new Color(192, 192, 192);
 	private static final Color CHECKBOX_GRAYED_COLOR = new Color(192, 192, 192);
@@ -135,7 +136,7 @@ public class DefaultCheckboxRenderer extends ButtonRenderer {
 
 		// Draw text
 		if (text != null && !text.isEmpty()) {
-			gc.setForeground(isEnabled() ? TEXT_COLOR : DISABLED_COLOR);
+			gc.setForeground(isEnabled() ? button.getForeground() : DISABLED_COLOR);
 			int textTopOffset = (height - 1 - textHeight) / 2;
 			int textLeftOffset = contentArea.x + imageSpace;
 			gc.drawText(text, textLeftOffset, textTopOffset, DRAW_FLAGS);
@@ -146,6 +147,16 @@ public class DefaultCheckboxRenderer extends ButtonRenderer {
 			gc.drawFocus(textLeftOffset - 2, textTopOffset, textWidth + 4,
 					textHeight);
 		}
+	}
+
+	@Override
+	public Color getDefaultBackground() {
+		return BACKGROUND_COLOR;
+	}
+
+	@Override
+	public Color getDefaultForeground() {
+		return FOREGROUND_COLOR;
 	}
 
 	private void drawCheckbox(GC gc, int x, int y) {
@@ -169,6 +180,9 @@ public class DefaultCheckboxRenderer extends ButtonRenderer {
 					BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1,
 					BOX_SIZE / 4 - partialBoxBorder / 2,
 					BOX_SIZE / 4 - partialBoxBorder / 2);
+		}
+		else {
+			gc.setForeground(FOREGROUND_COLOR);
 		}
 		gc.drawRoundRectangle(x, y, BOX_SIZE, BOX_SIZE, 4, 4);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultLinkRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultLinkRenderer.java
@@ -21,6 +21,11 @@ import org.eclipse.swt.graphics.*;
 
 public class DefaultLinkRenderer extends LinkRenderer {
 
+	private static final Color BACKGROUND_COLOR = new Color(240, 240, 240);
+	private static final Color FOREGROUND_COLOR = new Color(0, 0, 0);
+	private static final Color DISABLED_COLOR = new Color(160, 160, 160);
+	private static final Color LINK_COLOR = new Color(0, 102, 204);
+
 	private final Set<TextSegment> links = new HashSet<>();
 
 	public DefaultLinkRenderer(Link link) {
@@ -39,6 +44,8 @@ public class DefaultLinkRenderer extends LinkRenderer {
 		drawBackground(gc, width, height);
 
 		Color linkColor = link.getLinkForeground();
+		final boolean enabled = isEnabled();
+		Color textColor = enabled ? link.getForeground() : DISABLED_COLOR;
 
 		links.clear();
 
@@ -61,11 +68,7 @@ public class DefaultLinkRenderer extends LinkRenderer {
 			for (TextSegment segment : segments) {
 				Point extent = gc.textExtent(segment.text, DRAW_FLAGS);
 
-				if (isEnabled()) {
-					gc.setForeground(segment.isLink() ? linkColor : link.getForeground());
-				} else {
-					gc.setForeground(gc.getDevice().getSystemColor(SWT.COLOR_WIDGET_NORMAL_SHADOW));
-				}
+				gc.setForeground(enabled && segment.isLink() ? linkColor : textColor);
 				gc.drawText(segment.text, lineX, lineY, DRAW_FLAGS);
 
 				if (segment.isLink()) {
@@ -80,6 +83,16 @@ public class DefaultLinkRenderer extends LinkRenderer {
 			}
 			lineY += gc.getFontMetrics().getHeight();
 		}
+	}
+
+	@Override
+	public Color getDefaultBackground() {
+		return BACKGROUND_COLOR;
+	}
+
+	@Override
+	public Color getDefaultForeground() {
+		return FOREGROUND_COLOR;
 	}
 
 	private void drawBackground(GC gc, int width, int height) {
@@ -163,5 +176,10 @@ public class DefaultLinkRenderer extends LinkRenderer {
 			}
 		}
 		return false;
+	}
+
+	@Override
+	public Color getDefaultLinkColor() {
+		return LINK_COLOR;
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultRadioButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultRadioButtonRenderer.java
@@ -19,9 +19,10 @@ import org.eclipse.swt.graphics.*;
 
 public class DefaultRadioButtonRenderer extends ButtonRenderer {
 
+	private static final Color BACKGROUND_COLOR = new Color(240, 240, 240);
+	private static final Color FOREGROUND_COLOR = new Color(0, 0, 0);
 	private static final Color HOVER_COLOR = new Color(224, 238, 254);
 	private static final Color SELECTION_COLOR = new Color(0, 95, 184);
-	private static final Color TEXT_COLOR = new Color(0, 0, 0);
 	private static final Color DISABLED_COLOR = new Color(160, 160, 160);
 	private static final Color BORDER_DISABLED_COLOR = new Color(192, 192, 192);
 
@@ -134,7 +135,7 @@ public class DefaultRadioButtonRenderer extends ButtonRenderer {
 
 		// Draw text
 		if (text != null && !text.isEmpty()) {
-			gc.setForeground(isEnabled() ? TEXT_COLOR : DISABLED_COLOR);
+			gc.setForeground(isEnabled() ? button.getForeground() : DISABLED_COLOR);
 			int textTopOffset = (height - 1 - textHeight) / 2;
 			int textLeftOffset = contentArea.x + imageSpace;
 			gc.drawText(text, textLeftOffset, textTopOffset, DRAW_FLAGS);
@@ -145,6 +146,16 @@ public class DefaultRadioButtonRenderer extends ButtonRenderer {
 			gc.drawFocus(textLeftOffset - 2, textTopOffset, textWidth + 4,
 					textHeight);
 		}
+	}
+
+	@Override
+	public Color getDefaultBackground() {
+		return BACKGROUND_COLOR;
+	}
+
+	@Override
+	public Color getDefaultForeground() {
+		return FOREGROUND_COLOR;
 	}
 
 	private void drawRadioButton(GC gc, int x, int y) {
@@ -162,6 +173,9 @@ public class DefaultRadioButtonRenderer extends ButtonRenderer {
 			int partialBoxBorder = isSelected() ? 4 : 0;
 			gc.fillOval(x + partialBoxBorder, y + partialBoxBorder,
 					BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1);
+		}
+		else {
+			gc.setForeground(BACKGROUND_COLOR);
 		}
 		gc.drawOval(x, y, BOX_SIZE, BOX_SIZE);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultScaleRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultScaleRenderer.java
@@ -21,6 +21,8 @@ public class DefaultScaleRenderer extends ScaleRenderer {
 	private static final int PREFERRED_WIDTH = 170;
 	private static final int PREFERRED_HEIGHT = 42;
 
+	private static final Color BACKGROUND_COLOR = new Color(240, 240, 240);
+	private static final Color FOREGROUND_COLOR = new Color(0, 0, 0);
 	private static final Color IDLE_COLOR = new Color(0, 95, 184);
 	private static final Color HOVER_COLOR = new Color(0, 0, 0);
 	private static final Color DRAG_COLOR = new Color(204, 204, 204);
@@ -203,5 +205,15 @@ public class DefaultScaleRenderer extends ScaleRenderer {
 
 	private Point mirrorVertically(Point p) {
 		return new Point(getSize().x - p.x, p.y);
+	}
+
+	@Override
+	public Color getDefaultBackground() {
+		return BACKGROUND_COLOR;
+	}
+
+	@Override
+	public Color getDefaultForeground() {
+		return FOREGROUND_COLOR;
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultSliderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultSliderRenderer.java
@@ -19,6 +19,8 @@ public class DefaultSliderRenderer extends SliderRenderer {
 	private static final int PREFERRED_WIDTH = 170;
 	private static final int PREFERRED_HEIGHT = 18;
 
+	private static final Color BACKGROUND_COLOR = new Color(240, 240, 240);
+	private static final Color FOREGROUND_COLOR = new Color(0, 0, 0);
 	private static final Color TRACK_BACKGROUND = new Color(240, 240, 240);
 	private static final Color TRACK_FOREGROUND = new Color(204, 204, 204);
 	private static final Color THUMB_BACKGROUND = new Color(204, 204, 204);
@@ -158,5 +160,15 @@ public class DefaultSliderRenderer extends SliderRenderer {
 	@Override
 	public boolean getHovered() {
 		return thumbHovered;
+	}
+
+	@Override
+	public Color getDefaultBackground() {
+		return BACKGROUND_COLOR;
+	}
+
+	@Override
+	public Color getDefaultForeground() {
+		return FOREGROUND_COLOR;
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
@@ -130,6 +130,11 @@ public class Label extends CustomControl {
 		initAccessible();
 	}
 
+	@Override
+	protected ControlRenderer getRenderer() {
+		return renderer;
+	}
+
 	/**
 	 * Check the style bits to ensure that no invalid styles are applied.
 	 */
@@ -441,20 +446,6 @@ public class Label extends CustomControl {
 			renderer.setAlign(align);
 			redraw();
 		}
-	}
-
-	@Override
-	public void setBackground(Color color) {
-		super.setBackground(color);
-		renderer.setBackground(color);
-		redraw();
-	}
-
-	@Override
-	public void setForeground(Color color) {
-		super.setForeground(color);
-		renderer.setForeground(getForeground());
-		redraw();
 	}
 
 	/**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LabelRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LabelRenderer.java
@@ -25,7 +25,7 @@ public abstract class LabelRenderer extends ControlRenderer {
 	// the ellipsis glyph on
 	// some platforms "\u2026"
 
-	private final Label label;
+	protected final Label label;
 
 	protected static final int DEFAULT_MARGIN = 3;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Link.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Link.java
@@ -47,8 +47,6 @@ import org.eclipse.swt.widgets.LinkRenderer.*;
  */
 public class Link extends CustomControl {
 
-	private static final Color LINK_COLOR = new Color(0, 102, 204);
-
 	/** Left and right margins */
 	private static final int DEFAULT_MARGIN = 3;
 
@@ -134,6 +132,11 @@ public class Link extends CustomControl {
 		addListener(SWT.Dispose, listener);
 
 		initAccessible();
+	}
+
+	@Override
+	protected ControlRenderer getRenderer() {
+		return renderer;
 	}
 
 	private void onMouseUp(Event e) {
@@ -460,7 +463,7 @@ public class Link extends CustomControl {
 	 */
 	public Color getLinkForeground() {
 		checkWidget();
-		return linkColor != null ? linkColor : LINK_COLOR;
+		return linkColor != null ? linkColor : renderer.getDefaultLinkColor();
 	}
 
 	/**

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LinkRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LinkRenderer.java
@@ -22,10 +22,12 @@ import org.eclipse.swt.graphics.*;
 public abstract class LinkRenderer extends ControlRenderer {
 	public abstract boolean isOverLink(int x, int y);
 
+	public abstract Color getDefaultLinkColor();
+
 	protected static final int DRAW_FLAGS = SWT.DRAW_MNEMONIC | SWT.DRAW_TAB | SWT.DRAW_TRANSPARENT
 			| SWT.DRAW_DELIMITER;
-
 	protected final List<List<TextSegment>> parsedText = new ArrayList<>();
+
 	protected Link link;
 
 	public static class TextSegment {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Scale.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Scale.java
@@ -130,6 +130,10 @@ public class Scale extends CustomControl {
 		renderer = rendererFactory.createScaleRenderer(this);
 	}
 
+	@Override
+	protected ControlRenderer getRenderer() {
+		return renderer;
+	}
 
 	private static int checkStyle(int style) {
 		// Do not propagate this flags to the super class

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Slider.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Slider.java
@@ -169,6 +169,11 @@ public class Slider extends CustomControl {
 		super.style |= horizontal ? SWT.HORIZONTAL : SWT.VERTICAL;
 	}
 
+	@Override
+	protected ControlRenderer getRenderer() {
+		return renderer;
+	}
+
 	private static int checkStyle(int style) {
 		// Do not propagate this flags to the super class
 		style &= ~SWT.HORIZONTAL;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/toolbar/DefaultToolBarRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/toolbar/DefaultToolBarRenderer.java
@@ -25,6 +25,8 @@ import org.eclipse.swt.widgets.toolbar.ToolBarLayout.*;
  * Default renderer for the ToolBar.
  */
 public class DefaultToolBarRenderer extends ToolBarRenderer {
+	private static final Color BACKGROUND_COLOR = new Color(240, 240, 240);
+	private static final Color FOREGROUND_COLOR = new Color(0, 0, 0);
 	public static final Color COLOR_SEPARATOR = new Color(Display.getDefault(), 160, 160, 160);
 
 	private final ToolBar bar;
@@ -115,5 +117,15 @@ public class DefaultToolBarRenderer extends ToolBarRenderer {
 			rowCount = computeLayout(size).rows().size();
 		}
 		return rowCount;
+	}
+
+	@Override
+	public Color getDefaultBackground() {
+		return BACKGROUND_COLOR;
+	}
+
+	@Override
+	public Color getDefaultForeground() {
+		return FOREGROUND_COLOR;
 	}
 }


### PR DESCRIPTION
The custom controls should use the set background and foreground color and the getter should return a corresponding default color.