### PR TITLE
Renderers: directly access control getters

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/BasicLabelRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/BasicLabelRenderer.java
@@ -36,8 +36,8 @@ public class BasicLabelRenderer extends LabelRenderer {
 
 	@Override
 	public Point computeDefaultSize() {
-		final String text = getText();
-		final Image image = getImage();
+		final String text = label.getText();
+		final Image image = label.getImage();
 
 		int lineWidth = 0;
 		int lineHeight = 0;
@@ -72,8 +72,8 @@ public class BasicLabelRenderer extends LabelRenderer {
 
 	@Override
 	protected void paint(GC gc, int width, int height) {
-		String text = getText();
-		Image image = getImage();
+		String text = label.getText();
+		Image image = label.getImage();
 		if ((text == null || text.isEmpty()) && image == null) {
 			return;
 		}
@@ -124,6 +124,7 @@ public class BasicLabelRenderer extends LabelRenderer {
 			x = width - getRightMargin() - extent.x;
 		}
 
+		int style = label.getStyle();
 		// draw a background image behind the text
 		try {
 			final Image backgroundImage = getBackgroundImage();
@@ -200,14 +201,13 @@ public class BasicLabelRenderer extends LabelRenderer {
 				}
 			}
 		} catch (SWTException e) {
-			if ((getStyle() & SWT.DOUBLE_BUFFERED) == 0) {
+			if ((style & SWT.DOUBLE_BUFFERED) == 0) {
 				gc.setBackground(getBackground());
 				gc.fillRectangle(0, 0, width, height);
 			}
 		}
 
 		// draw border
-		int style = getStyle();
 		if ((style & SWT.SHADOW_IN) != 0 || (style & SWT.SHADOW_OUT) != 0) {
 			paintBorder(gc, width, height);
 		}
@@ -265,7 +265,7 @@ public class BasicLabelRenderer extends LabelRenderer {
 		}
 
 		if (lines != null) {
-			gc.setForeground(isEnabled() ? label.getForeground() : DISABLED_COLOR);
+			gc.setForeground(label.isEnabled() ? label.getForeground() : DISABLED_COLOR);
 			for (String line : lines) {
 				int lineX = x;
 				if (lines.length > 1) {
@@ -292,7 +292,7 @@ public class BasicLabelRenderer extends LabelRenderer {
 		Color c1 = null;
 		Color c2 = null;
 
-		int style = getStyle();
+		int style = label.getStyle();
 		if ((style & SWT.SHADOW_IN) != 0) {
 			c1 = SHADOW_IN_COLOR1;
 			c2 = SHADOW_IN_COLOR2;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Button.java
@@ -345,7 +345,7 @@ public class Button extends CustomControl {
 			forceFocus();
 			selectRadio();
 		} else if ((style & SWT.PUSH) == 0 && (style & (SWT.TOGGLE | SWT.CHECK)) != 0) {
-			setSelection(!renderer.isSelected());
+			setSelection(!checked);
 		}
 		sendSelectionEvent(SWT.Selection);
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ButtonRenderer.java
@@ -31,27 +31,11 @@ public abstract class ButtonRenderer extends ControlRenderer {
 		this.button = button;
 	}
 
-	protected final String getText() {
-		return button.getText();
-	}
-
-	protected final Image getImage() {
-		return button.getImage();
-	}
-
 	public void invalidateImage() {
 		if (disabledImage != null) {
 			disabledImage.dispose();
 			disabledImage = null;
 		}
-	}
-
-	protected final boolean isSelected() {
-		return button.getSelection();
-	}
-
-	protected final boolean isGrayed() {
-		return button.getGrayed();
 	}
 
 	protected final boolean isHover() {
@@ -71,8 +55,8 @@ public abstract class ButtonRenderer extends ControlRenderer {
 	}
 
 	protected final void drawImage(GC gc, int x, int y) {
-		final Image image = getImage();
-		if (isEnabled()) {
+		final Image image = button.getImage();
+		if (button.isEnabled()) {
 			gc.drawImage(image, x, y);
 		}
 		else {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ControlRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ControlRenderer.java
@@ -13,8 +13,10 @@
  *******************************************************************************/
 package org.eclipse.swt.widgets;
 
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Drawing;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Point;
 
 import java.util.function.Function;
 
@@ -33,27 +35,6 @@ public abstract class ControlRenderer {
 	public final void paint(GC gc) {
 		final Point size = control.getSize();
 		paint(gc, size.x, size.y);
-	}
-
-	protected final Point getSize() {
-		return control.getSize();
-	}
-
-	protected final boolean isEnabled() {
-		return control.isEnabled();
-	}
-
-	protected final boolean hasFocus() {
-		return control.hasFocus();
-	}
-
-	protected final int getStyle() {
-		return control.getStyle();
-	}
-
-	protected final boolean hasBorder() {
-		final int style = getStyle();
-		return (style & SWT.BORDER) != 0;
 	}
 
 	protected final <T> T measure(Function<GC, T> function) {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultArrowButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultArrowButtonRenderer.java
@@ -26,7 +26,8 @@ public class DefaultArrowButtonRenderer extends ButtonRenderer {
 	}
 
 	public Point computeDefaultSize() {
-		int borderWidth = hasBorder() ? 8 : 0;
+		final int style = button.getStyle();
+		int borderWidth = (style & SWT.BORDER) != 0 ? 8 : 0;
 		int width = 14 + borderWidth;
 		int height = 14 + borderWidth;
 		return new Point(width, height);
@@ -34,15 +35,16 @@ public class DefaultArrowButtonRenderer extends ButtonRenderer {
 
 	@Override
 	protected void paint(GC gc, int width, int height) {
-		if (hasFocus()) {
+		final int style = button.getStyle();
+		if (button.hasFocus()) {
 			gc.drawFocus(3, 3, width - 7, height - 7);
 		}
 
-		gc.setBackground(isEnabled() ? FOREGROUND_COLOR : DISABLED_COLOR);
+		gc.setBackground(button.isEnabled() ? FOREGROUND_COLOR : DISABLED_COLOR);
 
 		int centerHeight = height / 2;
 		int centerWidth = width / 2;
-		if (hasBorder()) {
+		if ((style & SWT.BORDER) != 0) {
 			// border ruins center position...
 			centerHeight -= 2;
 			centerWidth -= 2;
@@ -50,9 +52,7 @@ public class DefaultArrowButtonRenderer extends ButtonRenderer {
 
 		// TODO: in the next version use a bezier path
 
-		int[] curve = null;
-
-		final int style = getStyle();
+		int[] curve;
 		if ((style & SWT.DOWN) != 0) {
 			curve = new int[]{centerWidth, centerHeight + 5,
 					centerWidth - 5, centerHeight - 5, centerWidth + 5,

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultButtonRenderer.java
@@ -44,8 +44,8 @@ public class DefaultButtonRenderer extends ButtonRenderer {
 	}
 
 	public Point computeDefaultSize() {
-		final String text = getText();
-		final Image image = getImage();
+		final String text = button.getText();
+		final Image image = button.getImage();
 
 		int textWidth = 0;
 		int textHeight = 0;
@@ -80,9 +80,9 @@ public class DefaultButtonRenderer extends ButtonRenderer {
 
 	@Override
 	protected void paint(GC gc, int width, int height) {
-		final int style = getStyle();
-		final String text = getText();
-		final Image image = getImage();
+		final int style = button.getStyle();
+		final String text = button.getText();
+		final Image image = button.getImage();
 
 		boolean isRightAligned = (style & SWT.RIGHT) != 0;
 		boolean isCentered = (style & SWT.CENTER) != 0;
@@ -124,7 +124,7 @@ public class DefaultButtonRenderer extends ButtonRenderer {
 					/ 2;
 		}
 
-		boolean shiftDownRight = isPressed() || isSelected();
+		boolean shiftDownRight = isPressed() || button.getSelection();
 		// Draw image
 		if (image != null) {
 			int imageTopOffset = (height - imageHeight) / 2;
@@ -138,7 +138,7 @@ public class DefaultButtonRenderer extends ButtonRenderer {
 
 		// Draw text
 		if (text != null && !text.isEmpty()) {
-			gc.setForeground(isEnabled() ? button.getForeground() : DISABLED_COLOR);
+			gc.setForeground(button.isEnabled() ? button.getForeground() : DISABLED_COLOR);
 			int textTopOffset = (height - 1 - textHeight) / 2;
 			int textLeftOffset = contentArea.x + imageSpace;
 			if (shiftDownRight) {
@@ -147,7 +147,7 @@ public class DefaultButtonRenderer extends ButtonRenderer {
 			}
 			gc.drawText(text, textLeftOffset, textTopOffset, DRAW_FLAGS);
 		}
-		if (hasFocus()) {
+		if (button.hasFocus()) {
 			int inset = 2;
 			gc.drawFocus(inset, inset, width - 2 * inset - 1, height - 2 * inset - 1);
 		}
@@ -159,9 +159,9 @@ public class DefaultButtonRenderer extends ButtonRenderer {
 	}
 
 	private void drawPushButton(GC gc, int w, int h) {
-		final boolean isToggle = (getStyle() & SWT.TOGGLE) != 0;
-		if (isEnabled()) {
-			if (isToggle && isSelected()) {
+		final boolean isToggle = (button.getStyle() & SWT.TOGGLE) != 0;
+		if (button.isEnabled()) {
+			if (isToggle && button.getSelection()) {
 				gc.setBackground(TOGGLE_COLOR);
 			} else if (isPressed()) {
 				gc.setBackground(TOGGLE_COLOR);
@@ -171,10 +171,8 @@ public class DefaultButtonRenderer extends ButtonRenderer {
 				gc.setBackground(button.getBackground());
 			}
 			gc.fillRoundRectangle(0, 0, w, h, 6, 6);
-		}
 
-		if (isEnabled()) {
-			if (isToggle && isSelected() || isHover()) {
+			if (isToggle && button.getSelection() || isHover()) {
 				gc.setForeground(SELECTION_COLOR);
 			} else {
 				gc.setForeground(BORDER_COLOR);
@@ -185,7 +183,7 @@ public class DefaultButtonRenderer extends ButtonRenderer {
 
 		// if the button has focus, the border also changes the color
 		Color fg = gc.getForeground();
-		if (hasFocus()) {
+		if (button.hasFocus()) {
 			gc.setForeground(SELECTION_COLOR);
 		}
 		gc.drawRoundRectangle(0, 0, w - 1, h - 1, 6, 6);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultCheckboxRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultCheckboxRenderer.java
@@ -44,8 +44,8 @@ public class DefaultCheckboxRenderer extends ButtonRenderer {
 	}
 
 	public Point computeDefaultSize() {
-		final String text = getText();
-		final Image image = getImage();
+		final String text = button.getText();
+		final Image image = button.getImage();
 
 		int textWidth = 0;
 		int textHeight = 0;
@@ -77,9 +77,9 @@ public class DefaultCheckboxRenderer extends ButtonRenderer {
 
 	@Override
 	protected void paint(GC gc, int width, int height) {
-		final int style = getStyle();
-		final String text = getText();
-		final Image image = getImage();
+		final int style = button.getStyle();
+		final String text = button.getText();
+		final Image image = button.getImage();
 
 		boolean isRightAligned = (style & SWT.RIGHT) != 0;
 		boolean isCentered = (style & SWT.CENTER) != 0;
@@ -134,12 +134,12 @@ public class DefaultCheckboxRenderer extends ButtonRenderer {
 
 		// Draw text
 		if (text != null && !text.isEmpty()) {
-			gc.setForeground(isEnabled() ? button.getForeground() : DISABLED_COLOR);
+			gc.setForeground(button.isEnabled() ? button.getForeground() : DISABLED_COLOR);
 			int textTopOffset = (height - 1 - textHeight) / 2;
 			int textLeftOffset = contentArea.x + imageSpace;
 			gc.drawText(text, textLeftOffset, textTopOffset, DRAW_FLAGS);
 		}
-		if (hasFocus()) {
+		if (button.hasFocus()) {
 			int textTopOffset = (height - 1 - textHeight) / 2;
 			int textLeftOffset = contentArea.x + imageSpace;
 			gc.drawFocus(textLeftOffset - 2, textTopOffset, textWidth + 4,
@@ -148,9 +148,11 @@ public class DefaultCheckboxRenderer extends ButtonRenderer {
 	}
 
 	private void drawCheckbox(GC gc, int x, int y) {
-		if (isSelected()) {
-			gc.setBackground(isEnabled()
-					? isGrayed() ? CHECKBOX_GRAYED_COLOR : SELECTION_COLOR
+		final boolean enabled = button.isEnabled();
+		final boolean selection = button.getSelection();
+		if (selection) {
+			gc.setBackground(enabled
+					? button.getGrayed() ? CHECKBOX_GRAYED_COLOR : SELECTION_COLOR
 					: DISABLED_COLOR);
 			int partialBoxBorder = 2;
 			gc.fillRoundRectangle(x + partialBoxBorder, y + partialBoxBorder,
@@ -159,11 +161,11 @@ public class DefaultCheckboxRenderer extends ButtonRenderer {
 					BOX_SIZE / 4 - partialBoxBorder / 2);
 		}
 
-		if (!isEnabled()) {
+		if (!enabled) {
 			gc.setForeground(BORDER_DISABLED_COLOR);
 		} else if (isHover()) {
 			gc.setBackground(HOVER_COLOR);
-			int partialBoxBorder = isSelected() ? 4 : 0;
+			int partialBoxBorder = selection ? 4 : 0;
 			gc.fillRoundRectangle(x + partialBoxBorder, y + partialBoxBorder,
 					BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1,
 					BOX_SIZE / 4 - partialBoxBorder / 2,

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultLinkRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultLinkRenderer.java
@@ -41,7 +41,7 @@ public class DefaultLinkRenderer extends LinkRenderer {
 		drawBackground(gc, width, height);
 
 		Color linkColor = link.getLinkForeground();
-		final boolean enabled = isEnabled();
+		final boolean enabled = link.isEnabled();
 		Color textColor = enabled ? link.getForeground() : DISABLED_COLOR;
 
 		links.clear();
@@ -109,7 +109,7 @@ public class DefaultLinkRenderer extends LinkRenderer {
 				}
 			}
 		} catch (SWTException e) {
-			if ((getStyle() & SWT.DOUBLE_BUFFERED) == 0) {
+			if ((link.getStyle() & SWT.DOUBLE_BUFFERED) == 0) {
 				gc.setBackground(background);
 				gc.fillRectangle(0, 0, width, height);
 			}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultRadioButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultRadioButtonRenderer.java
@@ -43,8 +43,8 @@ public class DefaultRadioButtonRenderer extends ButtonRenderer {
 	}
 
 	public Point computeDefaultSize() {
-		final String text = getText();
-		final Image image = getImage();
+		final String text = button.getText();
+		final Image image = button.getImage();
 
 		int textWidth = 0;
 		int textHeight = 0;
@@ -76,9 +76,9 @@ public class DefaultRadioButtonRenderer extends ButtonRenderer {
 
 	@Override
 	protected void paint(GC gc, int width, int height) {
-		final int style = getStyle();
-		final String text = getText();
-		final Image image = getImage();
+		final int style = button.getStyle();
+		final String text = button.getText();
+		final Image image = button.getImage();
 
 		boolean isRightAligned = (style & SWT.RIGHT) != 0;
 		boolean isCentered = (style & SWT.CENTER) != 0;
@@ -133,12 +133,12 @@ public class DefaultRadioButtonRenderer extends ButtonRenderer {
 
 		// Draw text
 		if (text != null && !text.isEmpty()) {
-			gc.setForeground(isEnabled() ? button.getForeground() : DISABLED_COLOR);
+			gc.setForeground(button.isEnabled() ? button.getForeground() : DISABLED_COLOR);
 			int textTopOffset = (height - 1 - textHeight) / 2;
 			int textLeftOffset = contentArea.x + imageSpace;
 			gc.drawText(text, textLeftOffset, textTopOffset, DRAW_FLAGS);
 		}
-		if (hasFocus()) {
+		if (button.hasFocus()) {
 			int textTopOffset = (height - 1 - textHeight) / 2;
 			int textLeftOffset = contentArea.x + imageSpace;
 			gc.drawFocus(textLeftOffset - 2, textTopOffset, textWidth + 4,
@@ -147,8 +147,9 @@ public class DefaultRadioButtonRenderer extends ButtonRenderer {
 	}
 
 	private void drawRadioButton(GC gc, int x, int y) {
-		final boolean enabled = isEnabled();
-		if (isSelected()) {
+		final boolean enabled = button.isEnabled();
+		final boolean selection = button.getSelection();
+		if (selection) {
 			gc.setBackground(enabled ? SELECTION_COLOR : DISABLED_COLOR);
 			int partialBoxBorder = 2;
 			gc.fillOval(x + partialBoxBorder, y + partialBoxBorder,
@@ -159,7 +160,7 @@ public class DefaultRadioButtonRenderer extends ButtonRenderer {
 			gc.setForeground(BOX_COLOR);
 			if (isHover()) {
 				gc.setBackground(HOVER_COLOR);
-				int partialBoxBorder = isSelected() ? 4 : 0;
+				int partialBoxBorder = selection ? 4 : 0;
 				gc.fillOval(x + partialBoxBorder, y + partialBoxBorder,
 						BOX_SIZE - 2 * partialBoxBorder + 1, BOX_SIZE - 2 * partialBoxBorder + 1);
 			}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultScaleRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultScaleRenderer.java
@@ -57,9 +57,9 @@ public class DefaultScaleRenderer extends ScaleRenderer {
 
 	@Override
 	public void paint(GC gc, int width, int height) {
-		int value = getSelection();
-		int min = getMinimum();
-		int max = getMaximum();
+		int value = scale.getSelection();
+		int min = scale.getMinimum();
+		int max = scale.getMaximum();
 		int units = Math.max(1, max - min);
 		int effectiveValue = Math.min(max, Math.max(min, value));
 
@@ -90,7 +90,7 @@ public class DefaultScaleRenderer extends ScaleRenderer {
 		drawNotch(gc, lastNotch, 4);
 
 		// draw center notches
-		int unitPerPage = getPageIncrement();
+		int unitPerPage = scale.getPageIncrement();
 		double totalPixel = lastNotch - firstNotch;
 		ppu = totalPixel / units;
 		drawCenterNotches(gc, firstNotch, lastNotch, units, unitPerPage);
@@ -115,7 +115,7 @@ public class DefaultScaleRenderer extends ScaleRenderer {
 	private void drawHandle(GC gc, int value) {
 		// draw handle
 		Color handleColor;
-		if (isEnabled()) {
+		if (scale.isEnabled()) {
 			handleColor = switch (getHandleState()) {
 				case IDLE -> IDLE_COLOR;
 				case HOVER -> HOVER_COLOR;
@@ -149,7 +149,7 @@ public class DefaultScaleRenderer extends ScaleRenderer {
 	}
 
 	private boolean isRTL() {
-		return getOrientation() == SWT.RIGHT_TO_LEFT;
+		return scale.getOrientation() == SWT.RIGHT_TO_LEFT;
 	}
 
 	private void drawNotch(GC gc, int pos, int size) {
@@ -201,6 +201,6 @@ public class DefaultScaleRenderer extends ScaleRenderer {
 	}
 
 	private Point mirrorVertically(Point p) {
-		return new Point(getSize().x - p.x, p.y);
+		return new Point(scale.getSize().x - p.x, p.y);
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultSliderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultSliderRenderer.java
@@ -48,7 +48,7 @@ public class DefaultSliderRenderer extends SliderRenderer {
 		gc.setBackground(slider.getBackground());
 		gc.fillRectangle(0, 0, width, height);
 
-		gc.setForeground(isEnabled() ? slider.getForeground() : DISABLED_COLOR);
+		gc.setForeground(slider.isEnabled() ? slider.getForeground() : DISABLED_COLOR);
 
 		if (slider.isVertical()) {
 			int trackX = (width - 7) / 2;
@@ -104,7 +104,7 @@ public class DefaultSliderRenderer extends SliderRenderer {
 	private void drawRoundRectWithBorder(GC gc, Rectangle rect) {
 		final int arcSize = 10;
 		gc.fillRoundRectangle(rect.x, rect.y, rect.width + 1, rect.height + 1, arcSize, arcSize);
-		if (isEnabled()) {
+		if (slider.isEnabled()) {
 			gc.drawRoundRectangle(rect.x, rect.y, rect.width, rect.height, arcSize, arcSize);
 		}
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
@@ -54,6 +54,9 @@ public class Label extends CustomControl {
 
 	private final LabelRenderer renderer;
 
+	private String text;
+	private Image image;
+
 	private boolean ignoreDispose;
 
 	/**
@@ -231,7 +234,7 @@ public class Label extends CustomControl {
 		 * the widget.
 		 */
 		// checkWidget();
-		return renderer.getImage();
+		return image;
 	}
 
 	/**
@@ -291,7 +294,6 @@ public class Label extends CustomControl {
 		 * the widget.
 		 */
 		// checkWidget();
-		final String text = renderer.getText();
 		return text != null ? text : "";
 	}
 
@@ -333,7 +335,7 @@ public class Label extends CustomControl {
 
 			@Override
 			public void getKeyboardShortcut(AccessibleEvent e) {
-				char mnemonic = _findMnemonic(renderer.getText());
+				char mnemonic = _findMnemonic(text);
 				if (mnemonic != '\0') {
 					e.result = "Alt+" + mnemonic; //$NON-NLS-1$
 				}
@@ -383,11 +385,13 @@ public class Label extends CustomControl {
 		notifyListeners(event.type, event);
 		event.type = SWT.NONE;
 
+		text = null;
+		image = null;
 		renderer.dispose();
 	}
 
 	private void onMnemonic(Event event) {
-		char mnemonic = _findMnemonic(renderer.getText());
+		char mnemonic = _findMnemonic(text);
 		if (mnemonic == '\0') {
 			return;
 		}
@@ -612,8 +616,8 @@ public class Label extends CustomControl {
 	 */
 	public void setImage(Image image) {
 		checkWidget();
-		if (image != renderer.getImage()) {
-			renderer.setImage(image);
+		if (image != this.image) {
+			this.image = image;
 			redraw();
 		}
 	}
@@ -731,8 +735,8 @@ public class Label extends CustomControl {
 		if (text == null) {
 			text = ""; //$NON-NLS-1$
 		}
-		if (!text.equals(renderer.getText())) {
-			renderer.setText(text);
+		if (!text.equals(this.text)) {
+			this.text = text;
 			redraw();
 		}
 	}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LabelRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LabelRenderer.java
@@ -29,8 +29,6 @@ public abstract class LabelRenderer extends ControlRenderer {
 
 	protected static final int DEFAULT_MARGIN = 3;
 
-	private String text;
-	private Image image;
 	// The tooltip is used for two purposes - the application can set
 	// a tooltip or the tooltip can be used to display the full text when the
 	// the text has been truncated due to the label being too short.
@@ -56,22 +54,6 @@ public abstract class LabelRenderer extends ControlRenderer {
 	protected LabelRenderer(Label label) {
 		super(label);
 		this.label = label;
-	}
-
-	public String getText() {
-		return text;
-	}
-
-	public void setText(String text) {
-		this.text = text;
-	}
-
-	public Image getImage() {
-		return image;
-	}
-
-	public void setImage(Image image) {
-		this.image = image;
 	}
 
 	public int getLeftMargin() {
@@ -129,8 +111,6 @@ public abstract class LabelRenderer extends ControlRenderer {
 		gradientColors = null;
 		gradientPercents = null;
 		backgroundImage = null;
-		text = null;
-		setImage(null);
 		toolTipText = null;
 	}
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LinkRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LinkRenderer.java
@@ -24,6 +24,10 @@ public abstract class LinkRenderer extends ControlRenderer {
 
 	public abstract Color getDefaultLinkColor();
 
+	public abstract Set<TextSegment> getLinks();
+
+	public abstract Point computeDefaultSize();
+
 	protected static final int DRAW_FLAGS = SWT.DRAW_MNEMONIC | SWT.DRAW_TAB | SWT.DRAW_TRANSPARENT
 			| SWT.DRAW_DELIMITER;
 	protected final List<List<TextSegment>> parsedText = new ArrayList<>();
@@ -153,11 +157,8 @@ public abstract class LinkRenderer extends ControlRenderer {
 		return sb.toString();
 	}
 
+	@SuppressWarnings("unused")
 	public List<List<TextSegment>> getParsedSegments() {
 		return parsedText;
 	}
-
-	public abstract Set<TextSegment> getLinks();
-
-	public abstract Point computeDefaultSize();
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ScaleRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ScaleRenderer.java
@@ -54,27 +54,11 @@ public abstract class ScaleRenderer extends ControlRenderer {
 	 */
 	public abstract boolean isBeforeHandle(Point position);
 
-	private final Scale scale;
+	protected final Scale scale;
 
 	protected ScaleRenderer(Scale scale) {
 		super(scale);
 		this.scale = scale;
-	}
-
-	protected int getSelection() {
-		return scale.getSelection();
-	}
-
-	protected int getMinimum() {
-		return scale.getMinimum();
-	}
-
-	protected int getMaximum() {
-		return scale.getMaximum();
-	}
-
-	protected int getPageIncrement() {
-		return scale.getPageIncrement();
 	}
 
 	protected boolean isHorizontal() {
@@ -83,9 +67,5 @@ public abstract class ScaleRenderer extends ControlRenderer {
 
 	protected Scale.HandleState getHandleState() {
 		return scale.getHandleState();
-	}
-
-	protected int getOrientation() {
-		return scale.getOrientation();
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolBarRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolBarRenderer.java
@@ -35,7 +35,10 @@ public abstract class ToolBarRenderer extends ControlRenderer {
 	 */
 	public abstract int rowCount();
 
-	protected ToolBarRenderer(ToolBar control) {
-		super(control);
+	protected final ToolBar toolBar;
+
+	protected ToolBarRenderer(ToolBar toolBar) {
+		super(toolBar);
+		this.toolBar = toolBar;
 	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/toolbar/DefaultToolBarRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/toolbar/DefaultToolBarRenderer.java
@@ -28,12 +28,10 @@ public class DefaultToolBarRenderer extends ToolBarRenderer {
 
 	public static final Color COLOR_SEPARATOR = new Color(Display.getDefault(), 160, 160, 160);
 
-	private final ToolBar bar;
 	private int rowCount = SWT.DEFAULT;
 
 	public DefaultToolBarRenderer(ToolBar toolbar) {
 		super(toolbar);
-		this.bar = toolbar;
 	}
 
 	@Override
@@ -46,14 +44,14 @@ public class DefaultToolBarRenderer extends ToolBarRenderer {
 	}
 
 	private void render(GC gc, Point size, List<Row> rows) {
-		if (bar.isShadowOut()) {
+		if (toolBar.isShadowOut()) {
 			gc.setForeground(new Color(160, 160, 160));
 			gc.drawLine(0, 0, size.x, 0);
 		}
 
 		for (Row row : rows) {
 			for (ItemRecord itemRecord : row.items) {
-				final ToolItem item = bar.getItem(itemRecord.index());
+				final ToolItem item = toolBar.getItem(itemRecord.index());
 				item.render(gc, itemRecord.bounds());
 			}
 			if (row.hasRowSeparator) {
@@ -71,16 +69,16 @@ public class DefaultToolBarRenderer extends ToolBarRenderer {
 	private ToolBarLayout computeLayout(Point size) {
 		// Collect all item sizes
 		List<ItemRecord> itemRecords = new ArrayList<>();
-		for (int i = 0; i < bar.getItemCount(); i++) {
-			ToolItem item = bar.getItem(i);
+		for (int i = 0; i < toolBar.getItemCount(); i++) {
+			ToolItem item = toolBar.getItem(i);
 			Point preferredSize = item.getSize();
 			Rectangle initialBounds = new Rectangle(0, 0, preferredSize.x, preferredSize.y);
 			ItemRecord itemRecord = new ItemRecord(i, initialBounds, item.isSeparator());
 			itemRecords.add(itemRecord);
 		}
 
-		ToolBarLayoutGenerator generator = new ToolBarLayoutGenerator(itemRecords, size, bar.isHorizontal(),
-				bar.isWrap(), bar.isShadowOut(), bar.isRightToLeft(), bar.isFlat());
+		ToolBarLayoutGenerator generator = new ToolBarLayoutGenerator(itemRecords, size, toolBar.isHorizontal(),
+				toolBar.isWrap(), toolBar.isShadowOut(), toolBar.isRightToLeft(), toolBar.isFlat());
 
 		return generator.computeLayout();
 	}
@@ -91,7 +89,7 @@ public class DefaultToolBarRenderer extends ToolBarRenderer {
 		ToolBarLayout layout = computeLayout(new Point(widthHint, heightHint));
 
 		Point computedSize = layout.size();
-		if (bar.isBorder()) {
+		if (toolBar.isBorder()) {
 			computedSize.x += 4;
 			computedSize.y += 4;
 		}
@@ -112,7 +110,7 @@ public class DefaultToolBarRenderer extends ToolBarRenderer {
 	@Override
 	public int rowCount() {
 		if (rowCount == SWT.DEFAULT) {
-			Point size = getSize();
+			Point size = toolBar.getSize();
 			rowCount = computeLayout(size).rows().size();
 		}
 		return rowCount;


### PR DESCRIPTION
keep those attributes in the control that can be accessed without extending the control's API