### PR TITLE
Sash widget implementation using Skija

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SashWidgetExample.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Tests/common/org/eclipse/swt/snippets/SashWidgetExample.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2025 ETAS GmbH and others, all rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ETAS GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.snippets;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.graphics.*;
+import org.eclipse.swt.layout.*;
+import org.eclipse.swt.widgets.*;
+
+public class SashWidgetExample {
+	public static void main(String[] args) {
+		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setText("SWT Sash Example");
+		shell.setSize(500, 300);
+		shell.setLayout(new FormLayout());
+
+		// Left Composite
+		Composite leftComposite = new Composite(shell, SWT.BORDER);
+		leftComposite.setBackground(new Color(display, 255, 255, 153));
+
+		// Right Composite (Upper part)
+		Composite rightTopComposite = new Composite(shell, SWT.BORDER);
+		rightTopComposite.setBackground(new Color(display, 173, 216, 230));
+
+		// Right Composite (Lower part)
+		Composite rightBottomComposite = new Composite(shell, SWT.BORDER);
+		rightBottomComposite.setBackground(new Color(display, 144, 238, 144));
+
+		// Vertical Sash
+		Sash verticalSash = new Sash(shell, SWT.VERTICAL);
+		verticalSash.setBackground(display.getSystemColor(SWT.COLOR_GRAY));
+
+		// Horizontal Sash
+		Sash horizontalSash = new Sash(shell, SWT.HORIZONTAL);
+		horizontalSash.setBackground(display.getSystemColor(SWT.COLOR_GRAY));
+
+		// Layout Management
+		FormData leftData = new FormData();
+		leftData.left = new FormAttachment(0);
+		leftData.top = new FormAttachment(0);
+		leftData.bottom = new FormAttachment(100);
+		leftData.right = new FormAttachment(verticalSash);
+		leftComposite.setLayoutData(leftData);
+
+		FormData verticalSashData = new FormData();
+		verticalSashData.top = new FormAttachment(0);
+		verticalSashData.bottom = new FormAttachment(100);
+		verticalSashData.left = new FormAttachment(50, 0); // Start in the middle
+		verticalSash.setLayoutData(verticalSashData);
+
+		FormData rightTopData = new FormData();
+		rightTopData.left = new FormAttachment(verticalSash);
+		rightTopData.top = new FormAttachment(0);
+		rightTopData.bottom = new FormAttachment(horizontalSash);
+		rightTopData.right = new FormAttachment(100);
+		rightTopComposite.setLayoutData(rightTopData);
+
+		FormData horizontalSashData = new FormData();
+		horizontalSashData.left = new FormAttachment(verticalSash);
+		horizontalSashData.right = new FormAttachment(100);
+		horizontalSashData.top = new FormAttachment(50, 0);
+		horizontalSash.setLayoutData(horizontalSashData);
+
+		FormData rightBottomData = new FormData();
+		rightBottomData.left = new FormAttachment(verticalSash);
+		rightBottomData.top = new FormAttachment(horizontalSash);
+		rightBottomData.bottom = new FormAttachment(100);
+		rightBottomData.right = new FormAttachment(100);
+		rightBottomComposite.setLayoutData(rightBottomData);
+
+		// set the focus to the sash to enable dragging using the keyboard(Arrow
+		// keys/ctrl+Arrow keys)
+		verticalSash.setFocus();
+		// Vertical Sash Dragging Logic
+		verticalSash.addListener(SWT.Selection, e -> {
+			Rectangle sashRect = verticalSash.getBounds();
+			Rectangle shellRect = shell.getClientArea();
+			int right = shellRect.width - sashRect.width - 20;
+			e.x = Math.max(Math.min(e.x, right), 20);
+			if (e.x != sashRect.x) {
+				verticalSashData.left = new FormAttachment(0, e.x);
+				shell.layout();
+			}
+		});
+
+		// Horizontal Sash Dragging Logic
+		horizontalSash.addListener(SWT.Selection, e -> {
+			Rectangle sashRect = horizontalSash.getBounds();
+			Rectangle shellRect = shell.getClientArea();
+			int bottom = shellRect.height - sashRect.height - 20;
+			e.y = Math.max(Math.min(e.y, bottom), 20);
+			if (e.y != sashRect.y) {
+				horizontalSashData.top = new FormAttachment(0, e.y);
+				shell.layout();
+			}
+		});
+
+		shell.open();
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch()) {
+				display.sleep();
+			}
+		}
+		display.dispose();
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Sash_old.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/cocoa/org/eclipse/swt/widgets/Sash_old.java
@@ -40,7 +40,7 @@ import org.eclipse.swt.internal.cocoa.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  * @noextend This class is not intended to be subclassed by clients.
  */
-public class Sash extends Control {
+public class Sash_old extends Control {
 	Cursor sizeCursor;
 	boolean dragging;
 	int lastX, lastY, startX, startY;
@@ -78,7 +78,7 @@ public class Sash extends Control {
  * @see Widget#checkSubclass
  * @see Widget#getStyle
  */
-public Sash (Composite parent, int style) {
+public Sash_old(Composite parent, int style) {
 	super (parent, checkStyle (style));
 	int cursorStyle = (style & SWT.VERTICAL) != 0 ? SWT.CURSOR_SIZEWE : SWT.CURSOR_SIZENS;
 	sizeCursor = new Cursor (display, cursorStyle);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultRendererFactory.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultRendererFactory.java
@@ -63,4 +63,9 @@ class DefaultRendererFactory implements RendererFactory {
 	public CoolBarRenderer createCoolBarRenderer(CoolBar coolBar) {
 		return new DefaultCoolBarRenderer(coolBar);
 	}
+	
+	@Override
+	public SashRenderer createSashRenderer(Sash sash) {
+		return new DefaultSashRenderer(sash);
+	}
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultSashRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultSashRenderer.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) 2025 ETAS GmbH and others, all rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ETAS GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.graphics.*;
+
+/**
+ * Default implementation of the SashRenderer for rendering a Sash widget.
+ * Provides concrete implementations for painting, size computation, and drag
+ * handling.
+ */
+public class DefaultSashRenderer extends SashRenderer {
+
+	private static final int DEFAULT_WIDTH = 64;
+	private static final int DEFAULT_HEIGHT = 64;
+	private boolean isDragging;
+	private static final Color BACKGROUND_COLOR = new Color(240, 240, 240);
+	private static final Color FOREGROUND_COLOR = new Color(0, 0, 0);
+	private static final int SASH_MARGIN = 3;
+	private Rectangle sashBounds;
+
+	/**
+	 * Constructs a DefaultSashRenderer for the specified Sash.
+	 *
+	 * @param sash the Sash widget to be rendered.
+	 */
+	public DefaultSashRenderer(Sash sash) {
+		super(sash);
+		sashBounds = sash.getBounds();
+	}
+
+	/**
+	 * Computes the default size of the Sash based on its orientation.
+	 *
+	 * @return a Point representing the default width and height of the Sash.
+	 */
+	@Override
+	public Point computeDefaultSize() {
+		int width = 0;
+		int height = 0;
+		if (isHorizontal()) {
+			width += DEFAULT_WIDTH;
+			height += SASH_MARGIN;
+		} else {
+			width += SASH_MARGIN;
+			height += DEFAULT_HEIGHT;
+		}
+		return new Point(width, height);
+	}
+
+	/**
+	 * Draws a drag band for the Sash within the specified bounds.
+	 *
+	 * @param gc     the graphics context used for drawing.
+	 * @param bounds the bounds of the drag band to be drawn.
+	 */
+	@Override
+	protected void drawBand(GC gc, Rectangle bounds) {
+		if (super.isBrandRequired()) {
+			drawCheckerBoardPattern(gc, bounds);
+		}
+	}
+
+	/**
+	 * Draws a checkerboard pattern within the specified bounds.
+	 *
+	 * @param gc     the graphics context used for drawing.
+	 * @param bounds the bounds of the checkerboard pattern to be drawn.
+	 */
+	private void drawCheckerBoardPattern(GC gc, Rectangle bounds) {
+		int squareSize = 1;
+		for (int y1 = bounds.y; y1 < bounds.y + bounds.height; y1 += squareSize) {
+			for (int x1 = bounds.x; x1 < bounds.x + bounds.width; x1 += squareSize) {
+				if ((x1 / squareSize + y1 / squareSize) % 2 == 0) {
+					gc.setBackground(BACKGROUND_COLOR);
+				} else {
+					gc.setBackground(FOREGROUND_COLOR);
+				}
+				gc.fillRectangle(x1, y1, squareSize, squareSize);
+			}
+		}
+	}
+
+	/**
+	 * Sets the dragging state of the Sash.
+	 *
+	 * @param dragging true to indicate the Sash is being dragged; false otherwise.
+	 */
+	@Override
+	public void setDragging(boolean dragging) {
+		this.isDragging = dragging;
+	}
+
+	/**
+	 * Gets the current dragging state of the Sash.
+	 *
+	 * @return true if the Sash is being dragged; false otherwise.
+	 */
+	@Override
+	public boolean getDragging() {
+
+		return isDragging;
+	}
+
+	/**
+	 * Sets the bounds of the Sash.
+	 *
+	 * @param lastX  the x-coordinate of the Sash.
+	 * @param lastY  the y-coordinate of the Sash.
+	 * @param width  the width of the Sash.
+	 * @param height the height of the Sash.
+	 */
+	@Override
+	protected void setSashBounds(int lastX, int lastY, int width, int height) {
+		sashBounds = new Rectangle(lastX, lastY, width, height);
+	}
+
+	/**
+	 * Gets the bounds of the Sash.
+	 *
+	 * @return a Rectangle representing the bounds of the Sash.
+	 */
+	@Override
+	public Rectangle getSashBounds() {
+		return sashBounds;
+	}
+
+	/**
+	 * Gets the default background color of the Sash.
+	 *
+	 * @return the default background Color.
+	 */
+	@Override
+	public Color getDefaultBackground() {
+		return BACKGROUND_COLOR;
+	}
+
+	/**
+	 * Gets the default foreground color of the Sash.
+	 *
+	 * @return the default foreground Color.
+	 */
+	@Override
+	public Color getDefaultForeground() {
+		return FOREGROUND_COLOR;
+	}
+
+	/**
+	 * Paints the Sash with the specified width and height. The method sets the
+	 * background and fills the rectangle defined by the Sash bounds.
+	 *
+	 * @param gc     the graphics context used for painting.
+	 * @param width  the width of the Sash.
+	 * @param height the height of the Sash.
+	 */
+	@Override
+	protected void paint(GC gc, int width, int height) {
+		gc.setBackground(BACKGROUND_COLOR);
+		if (!super.isBrandRequired()) {
+			gc.fillRectangle(sashBounds);
+		}
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/RendererFactory.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/RendererFactory.java
@@ -33,4 +33,6 @@ public interface RendererFactory {
 	TabFolderRenderer createTabFolderRenderer(TabFolder tabFolder);
 
 	CoolBarRenderer createCoolBarRenderer(CoolBar coolBar);
+
+	SashRenderer createSashRenderer(Sash sash);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Sash.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Sash.java
@@ -1,0 +1,611 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Latha Patil (ETAS GmbH) - Custom draw Sash widget using SkijaGC
+ *******************************************************************************/
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.*;
+import org.eclipse.swt.events.*;
+import org.eclipse.swt.graphics.*;
+
+/**
+ * Instances of the receiver represent a selectable user interface object that
+ * allows the user to drag a rubber banded outline of the sash within the parent
+ * control.
+ * <dl>
+ * <dt><b>Styles:</b></dt>
+ * <dd>HORIZONTAL, VERTICAL, SMOOTH</dd>
+ * <dt><b>Events:</b></dt>
+ * <dd>Selection</dd>
+ * </dl>
+ * <p>
+ * Note: Only one of the styles HORIZONTAL and VERTICAL may be specified.
+ * </p>
+ * <p>
+ * IMPORTANT: This class is <em>not</em> intended to be subclassed.
+ * </p>
+ *
+ * @see <a href="http://www.eclipse.org/swt/snippets/#sash">Sash snippets</a>
+ * @see <a href="http://www.eclipse.org/swt/examples.php">SWT Example:
+ *      ControlExample</a>
+ * @see <a href="http://www.eclipse.org/swt/">Sample code and further
+ *      information</a>
+ * @noextend This class is not intended to be subclassed by clients.
+ */
+public class Sash extends CustomControl implements Listener {
+	int startX, startY, lastX, lastY;
+	final static int INCREMENT = 1;
+	final static int PAGE_INCREMENT = 9;
+	private final SashRenderer sashRenderer;
+	Shell dragOverlay;
+	private static final int DRAG_OVERLAY_ALPHA = 150;
+	private Image bandImage;
+	private Rectangle bandImageBounds;
+	private Cursor resizeCursor;
+	private boolean resizeCursorEnabled;
+	boolean isGTK;
+
+	/**
+	 * Constructs a new instance of this class given its parent and a style value
+	 * describing its behavior and appearance.
+	 * <p>
+	 * The style value is either one of the style constants defined in class
+	 * <code>SWT</code> which is applicable to instances of this class, or must be
+	 * built by <em>bitwise OR</em>'ing together (that is, using the
+	 * <code>int</code> "|" operator) two or more of those <code>SWT</code> style
+	 * constants. The class description lists the style constants that are
+	 * applicable to the class. Style bits are also inherited from superclasses.
+	 * </p>
+	 *
+	 * @param parent a composite control which will be the parent of the new
+	 *               instance (cannot be null)
+	 * @param style  the style of control to construct
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_NULL_ARGUMENT - if the parent
+	 *                                     is null</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     parent</li>
+	 *                                     <li>ERROR_INVALID_SUBCLASS - if this
+	 *                                     class is not an allowed subclass</li>
+	 *                                     </ul>
+	 *
+	 * @see SWT#HORIZONTAL
+	 * @see SWT#VERTICAL
+	 * @see SWT#SMOOTH
+	 * @see Widget#checkSubclass
+	 * @see Widget#getStyle
+	 */
+	public Sash(Composite parent, int style) {
+		super(parent, checkStyle(style));
+		isGTK = "gtk".equals(SWT.getPlatform());
+		int[] events = { SWT.KeyDown, SWT.MouseDown, SWT.MouseMove, SWT.MouseUp, SWT.Paint, SWT.Resize, SWT.Traverse,
+				SWT.MouseExit };
+
+		for (int eventType : events) {
+			if (isGTK) {
+				if (eventType != SWT.Paint) {
+					parent.addListener(eventType, this);
+				}
+				addListener(eventType, this);
+			} else {
+				addListener(eventType, this);
+			}
+		}
+		final RendererFactory rendererFactory = parent.getDisplay().getRendererFactory();
+		sashRenderer = rendererFactory.createSashRenderer(this);
+	}
+
+	@Override
+	public void handleEvent(Event event) {
+		switch (event.type) {
+		case SWT.KeyDown -> onKeyDown(event);
+		case SWT.MouseDown -> onLeftMouseDown(event);
+		case SWT.MouseMove -> onMouseMove(event);
+		case SWT.MouseExit -> onMouseExit(event);
+		case SWT.MouseUp -> onLeftMouseUp(event);
+		case SWT.Paint -> onPaint(event);
+		case SWT.Resize -> {
+			getParent().redraw();
+			redraw();
+		}
+		case SWT.Traverse -> onTraverse(event);
+		}
+	}
+
+	/**
+	 * Handles the `SWT.Traverse` event to prevent traversal when arrow keys are
+	 * used. This ensures that the arrow keys are processed by the `SWT.KeyDown`
+	 * listener instead of moving focus to other controls.
+	 *
+	 * @param event the traverse event containing details about the traversal action
+	 */
+	private void onTraverse(Event event) {
+		// Prevent traversal for arrow keys
+		if (event.detail == SWT.TRAVERSE_ARROW_PREVIOUS || event.detail == SWT.TRAVERSE_ARROW_NEXT) {
+			event.doit = false;
+		}
+	}
+
+	/**
+	 * Handles the `SWT.KeyDown` event to allow keyboard navigation of the sash.
+	 * Arrow keys are used to move the sash, and the movement step is determined by
+	 * whether the CTRL key is pressed (small step) or not (page increment).
+	 *
+	 * @param event the key event containing details about the key press
+	 */
+	private void onKeyDown(Event event) {
+		KeyEvent keyEvent = new KeyEvent(event);
+		int key = keyEvent.keyCode;
+		boolean leftMouseButtonPressed = (keyEvent.stateMask & SWT.BUTTON1) != 0;
+
+		if (leftMouseButtonPressed) {
+			return;
+		}
+		boolean isArrowKey = switch (key) {
+		case SWT.ARROW_LEFT, SWT.ARROW_RIGHT, SWT.ARROW_UP, SWT.ARROW_DOWN -> true;
+		default -> false;
+		};
+
+		boolean isRelevantKey = (!isArrowKey || (isHorizontal() && (key == SWT.ARROW_UP || key == SWT.ARROW_DOWN))
+				|| (!isHorizontal() && (key == SWT.ARROW_LEFT || key == SWT.ARROW_RIGHT)));
+		if (!isRelevantKey) {
+			return;
+		}
+		int step = sashStepCalculation(keyEvent);
+		Rectangle sashBounds = sashRenderer.getSashBounds();
+		Point newSashPosition = calculateNewSashPosition(step, sashBounds);
+
+		if (newSashPosition.x == sashBounds.x && newSashPosition.y == sashBounds.y) {
+			return;
+		}
+
+		Display.getCurrent().setCursorLocation(newSashPosition.x, newSashPosition.y);
+		Event selectionEvent = sendSelectionEvent(
+				new Rectangle(newSashPosition.x, newSashPosition.y, sashBounds.width, sashBounds.height));
+		if (selectionEvent.doit) {
+			asyncRedraw(this);
+		}
+	}
+
+	private Point calculateNewSashPosition(int step, Rectangle sashBounds) {
+		Rectangle clientArea = parent.getClientArea();
+		int newX = sashBounds.x, newY = sashBounds.y;
+		if (isHorizontal()) {
+			newX = sashBounds.x + sashBounds.width / 2;
+			newY = Math.min(Math.max(clientArea.y, newY + step), clientArea.height - sashBounds.height);
+		} else {
+			newX = Math.min(Math.max(clientArea.x, newX + step), clientArea.width - sashBounds.width);
+			newY = sashBounds.y + sashBounds.height / 2;
+		}
+		return new Point(newX, newY);
+	}
+
+	private int sashStepCalculation(KeyEvent keyEvent) {
+		int key = keyEvent.keyCode;
+		boolean mirrored = (parent.getStyle() & SWT.MIRRORED) != 0;
+		boolean ctrlPressed = (keyEvent.stateMask & SWT.CTRL) != 0;
+		int step = ctrlPressed ? INCREMENT : PAGE_INCREMENT;
+		if (isHorizontal()) {
+			step = (key == SWT.ARROW_UP) ? -step : step;
+		} else {
+			step = (key == SWT.ARROW_LEFT) ? -step : step;
+			step = mirrored ? -step : step;
+		}
+		return step;
+	}
+
+	/**
+	 * Handles the `SWT.MouseDown` event for the left mouse button. This method
+	 * initiates the dragging process for the sash when the left mouse button is
+	 * pressed. It sets up the initial drag state, including the starting position
+	 * and the sash's current position. If the `SWT.SMOOTH` style is not set, a drag
+	 * overlay is created to visually represent the sash's movement.
+	 *
+	 * @param e the mouse event containing details about the mouse action
+	 */
+	private void onLeftMouseDown(Event e) {
+		if (e.button != 1) {
+			return;
+		}
+		Rectangle sashBounds = isGTK ? getBounds() : sashRenderer.getSashBounds();
+		if (sashBounds == null) {
+			System.out.println("Return");
+			return;
+		}
+		if (isGTK && e.widget == getParent()) {
+			if (!(sashBounds.contains(e.x, e.y))) {
+				return;
+			}
+			e = convertToSash(e);
+		}
+		sashRenderer.setDragging(true);
+		startX = e.x;
+		startY = e.y;
+		lastX = sashBounds.x;
+		lastY = sashBounds.y;
+
+		Event event = sendSelectionEvent(new Rectangle(lastX, lastY, sashBounds.width, sashBounds.height));
+		if (!isSmooth()) {
+			event.detail = SWT.DRAG;
+		}
+		if (event.doit && !isSmooth()) {
+			dragOverlay = createDragOverlay();
+			createBandImage();
+			redrawDragOverlay();
+		}
+	}
+
+	private Event convertToSash(Event e) {
+		Event ret = new Event();
+		var b = getBounds();
+		ret.widget = this;
+		ret.x = e.x - b.x;
+		ret.y = e.y - b.y;
+		ret.doit = e.doit;
+		return ret;
+	}
+
+	private void createBandImage() {
+		if (bandImage != null) {
+			bandImage.dispose();
+		}
+		Rectangle bounds = isGTK ? getBounds() : sashRenderer.getSashBounds();
+
+		if (bounds.width == 0 || bounds.height == 0) {
+			return;
+		}
+
+		bandImageBounds = new Rectangle(0, 0, bounds.width, bounds.height);
+		bandImage = new Image(getDisplay(), bandImageBounds);
+
+		GC gc = new GC(bandImage);
+		Drawing.drawWithGC(this, gc, g -> {
+			sashRenderer.drawBand(g, bandImageBounds);
+		});
+		gc.dispose();
+	}
+
+	private Event sendSelectionEvent(Rectangle sashBounds) {
+		Event event = new Event();
+		event.setBounds(new Rectangle(sashBounds.x, sashBounds.y, sashBounds.width, sashBounds.height));
+		sendSelectionEvent(SWT.Selection, event, true);
+		return event;
+	}
+
+	private Shell createDragOverlay() {
+		Shell overlay = new Shell(parent.getShell(), SWT.NO_TRIM | SWT.NO_FOCUS | SWT.ON_TOP);
+		overlay.setAlpha(DRAG_OVERLAY_ALPHA);
+		overlay.setBounds(parent.toDisplay(0, 0).x, parent.toDisplay(0, 0).y, parent.getSize().x, parent.getSize().y);
+		overlay.setBackground(display.getSystemColor(SWT.COLOR_TRANSPARENT));
+		overlay.setVisible(true);
+		return overlay;
+	}
+
+	private void redrawDragOverlay() {
+		dragOverlay.addListener(SWT.Paint, dragEvent -> {
+			if (bandImage != null) {
+				/** Band flicker and moves slowly using below commented API **/
+//				Drawing.drawWithGC(dragOverlay, dragEvent.gc, gc -> {
+//					gc.drawImage(bandImage, 0, 0, bandImageBounds.width, bandImageBounds.height, lastX, lastY,
+//							bandImageBounds.width, bandImageBounds.height);
+//				});
+				dragEvent.gc.drawImage(bandImage, 0, 0, bandImageBounds.width, bandImageBounds.height, lastX, lastY,
+						bandImageBounds.width, bandImageBounds.height);
+			}
+		});
+		asyncRedraw(dragOverlay);
+	}
+
+	/**
+	 * Handles the `SWT.MouseUp` event for the left mouse button. This method
+	 * finalizes the dragging process for the sash when the left mouse button is
+	 * released. It stops the dragging state, disposes of the drag overlay if it
+	 * exists, and sends a selection event. The method also ensures the sash is
+	 * redrawn after the drag operation is completed.
+	 *
+	 * @param event the mouse event containing details about the mouse action
+	 */
+	private void onLeftMouseUp(Event event) {
+		if (event.button != 1 || !sashRenderer.getDragging()) {
+			return;
+		}
+		sashRenderer.setDragging(false);
+		if ((!isSmooth() && dragOverlay != null && !dragOverlay.isDisposed())) {
+			dragOverlay.dispose();
+			dragOverlay = null;
+		}
+		Rectangle sashRecatngle = sashRenderer.getSashBounds();
+		sendSelectionEvent(new Rectangle(lastX, lastY, sashRecatngle.width, sashRecatngle.height));
+
+		if (bandImage != null) {
+			bandImage.dispose();
+			bandImage = null;
+		}
+		if (!isDisposed()) {
+			asyncRedraw(this);
+		}
+	}
+
+	/**
+	 * Handles the `SWT.MouseMove` event. This method updates the cursor to indicate
+	 * resizing and processes the dragging of the sash if the dragging state is
+	 * active. It calculates the new position of the sash based on the mouse
+	 * movement and updates the sash's bounds. If the `SWT.SMOOTH` style is set, it
+	 * sends a selection event with the updated bounds. Otherwise, it updates the
+	 * drag overlay or redraws the sash.
+	 *
+	 * @param event the mouse event containing details about the mouse movement
+	 */
+	private void onMouseMove(Event event) {
+		boolean dragging = sashRenderer.getDragging();
+		boolean eventFromParent = event.widget == getParent();
+
+		Rectangle sashBounds = getBounds();
+		if (sashBounds == null) {
+			return;
+		}
+		boolean insideSash = isGTK ? sashBounds.contains(event.x, event.y)
+				: sashBounds.contains(event.x + sashBounds.x, event.y + sashBounds.y);
+
+		if (isGTK && eventFromParent) {
+			if (eventFromParent) {
+				event = convertToSash(event);
+			}
+		}
+		// Show resize cursor when inside bounds
+		if (insideSash && !resizeCursorEnabled) {
+			if (resizeCursor == null || resizeCursor.isDisposed()) {
+				resizeCursor = new Cursor(display, isHorizontal() ? SWT.CURSOR_SIZENS : SWT.CURSOR_SIZEWE);
+			}
+			parent.setCursor(resizeCursor);
+			setCursor(resizeCursor);
+			resizeCursorEnabled = true;
+		}
+
+		// Hide resize cursor when mouse leaves and not dragging
+		if (!insideSash && resizeCursorEnabled && !dragging) {
+			parent.setCursor(null);
+			setCursor(null);
+			resizeCursorEnabled = false;
+		}
+
+		if (!sashRenderer.getDragging()) {
+			return;
+		}
+
+		Rectangle clientArea = getParent().getClientArea();
+		Point currentPoint = getCurrentPoint(event, sashBounds);
+		int newX = lastX, newY = lastY;
+
+		if (!isHorizontal()) {
+			int maxX = clientArea.width - sashBounds.width;
+			newX = Math.min(Math.max(0, currentPoint.x - startX), maxX);
+		} else {
+			int maxY = clientArea.height - sashBounds.height;
+			newY = Math.min(Math.max(0, currentPoint.y - startY), maxY);
+		}
+
+		if (newX == lastX && newY == lastY) {
+			return;
+		}
+		if (isSmooth()) {
+			Event selectionEvent = sendSelectionEvent(new Rectangle(newX, newY, sashBounds.width, sashBounds.height));
+			if (isDisposed() || !selectionEvent.doit) {
+				return;
+			}
+			Rectangle bounds = selectionEvent.getBounds();
+			lastX = bounds.x;
+			lastY = bounds.y;
+		} else {
+			lastX = newX;
+			lastY = newY;
+		}
+		sashRenderer.setSashBounds(lastX, lastY, sashBounds.width, sashBounds.height);
+		Control target = isSmooth() ? this : dragOverlay;
+		if (!isSmooth()) {
+			dragOverlay.setVisible(true);
+		}
+		asyncRedraw(target);
+	}
+
+	private void onMouseExit(Event event) {
+		if (!sashRenderer.getDragging() && this.resizeCursorEnabled) {
+			parent.setCursor(null);
+			setCursor(null);
+			this.resizeCursorEnabled = false;
+		}
+	}
+
+	private boolean isSmooth() {
+		return (style & SWT.SMOOTH) != 0;
+	}
+
+	/**
+	 * Calculates and returns the current point based on the given event and sash
+	 * bounds. This method determines the appropriate coordinates for the current
+	 * mouse position, taking into account whether the `SWT.SMOOTH` style is
+	 * applied.
+	 *
+	 * @param event      the mouse event containing the current x and y coordinates
+	 * @param sashBounds the bounds of the sash, used for coordinate adjustments
+	 * @return a `Point` object representing the current x and y coordinates
+	 */
+	private Point getCurrentPoint(Event event, Rectangle sashBounds) {
+		Point currentPoint = new Point(event.x, event.y);
+		if (isSmooth()) {
+			if (event.x < sashBounds.x) {
+				event.x += sashBounds.x;
+			}
+			if (event.y < sashBounds.y) {
+				event.y += sashBounds.y;
+			}
+			currentPoint = new Point(event.x, event.y);
+		} else {
+			currentPoint = getDisplay().map(this, dragOverlay, event.x, event.y);
+		}
+		return currentPoint;
+	}
+
+	private void asyncRedraw(Control control) {
+		Display.getDefault().asyncExec(() -> {
+			if (!control.isDisposed())
+				control.redraw();
+		});
+	}
+
+	/**
+	 * Handles the `SWT.Paint` event. This method is responsible for rendering the
+	 * sash. It sets the bounds of the sash and delegates the actual painting to the
+	 * `SashRenderer` instance.
+	 *
+	 * @param event the paint event containing details about the painting action
+	 */
+	private void onPaint(Event event) {
+		Rectangle sashBounds = getBounds();
+		sashRenderer.setSashBounds(sashBounds.x, sashBounds.y, sashBounds.width, sashBounds.height);
+		Drawing.drawWithGC(this, event.gc, gc -> sashRenderer.paint(gc, sashBounds.width, sashBounds.height));
+	}
+
+	/**
+	 * Adds the listener to the collection of listeners who will be notified when
+	 * the control is selected by the user, by sending it one of the messages
+	 * defined in the <code>SelectionListener</code> interface.
+	 * <p>
+	 * When <code>widgetSelected</code> is called, the x, y, width, and height
+	 * fields of the event object are valid. If the receiver is being dragged, the
+	 * event object detail field contains the value <code>SWT.DRAG</code>.
+	 * <code>widgetDefaultSelected</code> is not called.
+	 * </p>
+	 *
+	 * @param listener the listener which should be notified when the control is
+	 *                 selected by the user
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_NULL_ARGUMENT - if the listener
+	 *                                     is null</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 *
+	 * @see SelectionListener
+	 * @see #removeSelectionListener
+	 * @see SelectionEvent
+	 */
+	public void addSelectionListener(SelectionListener listener) {
+		addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
+	}
+
+	/**
+	 * Validates and returns the appropriate style for the Sash widget. This method
+	 * ensures that only one of the mutually exclusive styles (HORIZONTAL or
+	 * VERTICAL) is applied. If no valid style is provided, it defaults to 0.
+	 *
+	 * @param style the style value to be checked
+	 * @return the validated style value, ensuring only one of the valid styles is
+	 *         applied
+	 */
+	static int checkStyle(int style) {
+		return checkBits(style, SWT.HORIZONTAL, SWT.VERTICAL, 0, 0, 0, 0);
+	}
+
+	/**
+	 * Removes the listener from the collection of listeners who will be notified
+	 * when the control is selected by the user.
+	 *
+	 * @param listener the listener which should no longer be notified
+	 *
+	 * @exception IllegalArgumentException
+	 *                                     <ul>
+	 *                                     <li>ERROR_NULL_ARGUMENT - if the listener
+	 *                                     is null</li>
+	 *                                     </ul>
+	 * @exception SWTException
+	 *                                     <ul>
+	 *                                     <li>ERROR_WIDGET_DISPOSED - if the
+	 *                                     receiver has been disposed</li>
+	 *                                     <li>ERROR_THREAD_INVALID_ACCESS - if not
+	 *                                     called from the thread that created the
+	 *                                     receiver</li>
+	 *                                     </ul>
+	 *
+	 * @see SelectionListener
+	 * @see #addSelectionListener
+	 */
+	public void removeSelectionListener(SelectionListener listener) {
+		checkWidget();
+		if (listener == null)
+			error(SWT.ERROR_NULL_ARGUMENT);
+		removeListener(SWT.Selection, listener);
+		removeListener(SWT.DefaultSelection, listener);
+	}
+
+	/**
+	 * Computes and returns the default size of the Sash widget. This method
+	 * delegates the computation to the `SashRenderer` instance.
+	 *
+	 * @return a `Point` object representing the default width and height of the
+	 *         Sash
+	 */
+	@Override
+	protected Point computeDefaultSize() {
+		return sashRenderer.computeDefaultSize();
+	}
+
+	/**
+	 * Determines whether the Sash is oriented horizontally.
+	 *
+	 * @return `true` if the Sash is horizontal, `false` otherwise
+	 */
+	public boolean isHorizontal() {
+		return (style & SWT.VERTICAL) == 0;
+	}
+
+	/**
+	 * This method returns the `SashRenderer` instance used for rendering the Sash.
+	 *
+	 * @return the `ControlRenderer` instance for the Sash
+	 */
+	@Override
+	protected ControlRenderer getRenderer() {
+		return sashRenderer;
+	}
+
+	@Override
+	public void dispose() {
+		if (this.resizeCursor != null && !this.resizeCursor.isDisposed()) {
+			this.resizeCursor.dispose();
+		}
+		if (isGTK && !getParent().isDisposed()) {
+			parent.removeListener(SWT.KeyDown, this);
+			parent.removeListener(SWT.MouseDown, this);
+			parent.removeListener(SWT.MouseMove, this);
+			parent.removeListener(SWT.MouseUp, this);
+			parent.removeListener(SWT.Resize, this);
+			parent.removeListener(SWT.Traverse, this);
+		}
+		super.dispose();
+	}
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/SashRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/SashRenderer.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2025 ETAS GmbH and others, all rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ETAS GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.graphics.*;
+
+/**
+ * Abstract class for rendering a Sash widget in the SWT framework. This class
+ * provides a base for implementing custom rendering logic for a Sash, including
+ * painting, size computation, and drag handling.
+ */
+public abstract class SashRenderer extends ControlRenderer {
+
+	/**
+	 * Computes the default size of the Sash.
+	 *
+	 * @return a {@link Point} representing the default width and height of the
+	 *         Sash.
+	 */
+	public abstract Point computeDefaultSize();
+
+	/**
+	 * The Sash widget associated with this renderer.
+	 */
+	protected final Sash sash;
+
+	/**
+	 * Constructs a new SashRenderer for the specified Sash.
+	 *
+	 * @param sash the Sash widget to be rendered.
+	 */
+	protected SashRenderer(Sash sash) {
+		super(sash);
+		this.sash = sash;
+	}
+
+	/**
+	 * Determines if the Sash is oriented horizontally.
+	 *
+	 * @return true if the Sash is horizontal, false otherwise.
+	 */
+	protected boolean isHorizontal() {
+		return sash.isHorizontal();
+	}
+
+	/**
+	 * Checks if a drag overlay (brand) is required for the Sash.
+	 *
+	 * @return true if the drag overlay is enabled and visible, false otherwise.
+	 */
+	protected boolean isBrandRequired() {
+		return sash.dragOverlay != null && sash.dragOverlay.isEnabled() && sash.dragOverlay.isVisible();
+	}
+
+	/**
+	 * Sets the dragging state of the Sash.
+	 *
+	 * @param dragging true to indicate the Sash is being dragged, false otherwise.
+	 */
+	protected abstract void setDragging(boolean dragging);
+
+	/**
+	 * Gets the current dragging state of the Sash.
+	 *
+	 * @return true if the Sash is being dragged, false otherwise.
+	 */
+	protected abstract boolean getDragging();
+
+	/**
+	 * Gets the bounds of the Sash.
+	 *
+	 * @return a {@link Rectangle} representing the bounds of the Sash.
+	 */
+	protected abstract Rectangle getSashBounds();
+
+	/**
+	 * Sets the bounds of the Sash.
+	 *
+	 * @param x      the x-coordinate of the Sash.
+	 * @param y      the y-coordinate of the Sash.
+	 * @param width  the width of the Sash.
+	 * @param height the height of the Sash.
+	 */
+	protected abstract void setSashBounds(int x, int y, int width, int height);
+
+	/**
+	 * Draws a drag band for the Sash within the specified bounds.
+	 *
+	 * @param gc     the graphics context used for drawing.
+	 * @param bounds the bounds of the drag band to be drawn.
+	 */
+	protected abstract void drawBand(GC gc, Rectangle bounds);
+}

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Sash_old.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Sash_old.java
@@ -43,7 +43,7 @@ import org.eclipse.swt.internal.gtk4.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  * @noextend This class is not intended to be subclassed by clients.
  */
-public class Sash extends Control {
+public class Sash_old extends Control {
 	boolean dragging;
 	int startX, startY, lastX, lastY;
 	long defaultCursor;
@@ -83,7 +83,7 @@ public class Sash extends Control {
  * @see Widget#checkSubclass
  * @see Widget#getStyle
  */
-public Sash(Composite parent, int style) {
+public Sash_old(Composite parent, int style) {
 	super(parent, checkStyle(style));
 }
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Sash_old.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/win32/org/eclipse/swt/widgets/Sash_old.java
@@ -41,7 +41,7 @@ import org.eclipse.swt.internal.win32.*;
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
  * @noextend This class is not intended to be subclassed by clients.
  */
-public class Sash extends Control {
+public class Sash_old extends Control {
 	boolean dragging;
 	int startX, startY, lastX, lastY;
 	final static int INCREMENT = 1;
@@ -77,7 +77,7 @@ public class Sash extends Control {
  * @see Widget#checkSubclass
  * @see Widget#getStyle
  */
-public Sash (Composite parent, int style) {
+public Sash_old(Composite parent, int style) {
 	super (parent, checkStyle (style));
 }
 


### PR DESCRIPTION
**Known Issues :**

1. **First Commit:**  Uses purely `SkijaGC`, where the Sash band flickers and redraws slowly compared to the mouse movement.

    **Second (Latest) Commit:** Uses the native `GC` to create a band `Image` and draws it using the native `drawImage` API, 
       which performs as expected.
       Difference between 2 commits lies in method `redrawDragOverlay()` 

2. The behavior of `Snippet107` and `SashWidgetExample` differs when tested on SWT for Windows (using Win32 APIs).

other Examples used to test :
`GraphicsExample`
`ControlExample`