### PR TITLE
Text: fix <tab> handling

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Text.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Text.java
@@ -450,9 +450,7 @@ public class Text extends NativeBasedCustomScrollable {
 	private void onTraverse(Event e) {
 		switch (e.detail) {
 		case SWT.TRAVERSE_TAB_NEXT -> {
-			if ((style & SWT.MULTI) == 0 || (e.stateMask & SWT.MODIFIER_MASK) == 0) {
-				e.doit = false;
-			}
+			e.doit = (style & SWT.MULTI) == 0 || (e.stateMask & SWT.MODIFIER_MASK & ~SWT.SHIFT) == SWT.MOD1;
 		}
 		default -> e.doit = false;
 		}


### PR DESCRIPTION
- for a single-line text field, pressing <tab> should move focus to the next control
- for a multi-line text field, pressing <tab> should insert a tab character; to move the focus to the next control, Ctrl+<tab> is required