### PR TITLE
Maintain official SWT API

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/BasicLabelRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/BasicLabelRenderer.java
@@ -17,7 +17,7 @@ package org.eclipse.swt.widgets;
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 
-public class BasicLabelRenderer extends LabelRenderer {
+class BasicLabelRenderer extends LabelRenderer {
 
 	private static final Color SHADOW_IN_COLOR1 = new Color(160, 160, 160);
 	private static final Color SHADOW_IN_COLOR2 = new Color(255, 255, 255);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultButtonRenderer.java
@@ -17,7 +17,7 @@ package org.eclipse.swt.widgets;
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 
-public class DefaultButtonRenderer extends ButtonRenderer {
+class DefaultButtonRenderer extends ButtonRenderer {
 
 	private static final Color BACKGROUND_COLOR = new Color(255, 255, 255);
 	private static final Color HOVER_COLOR = new Color(224, 238, 254);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultLinkRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultLinkRenderer.java
@@ -19,7 +19,7 @@ import java.util.List;
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 
-public class DefaultLinkRenderer extends LinkRenderer {
+class DefaultLinkRenderer extends LinkRenderer {
 
 	private static final Color LINK_COLOR = new Color(0, 102, 204);
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultRendererFactory.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultRendererFactory.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.swt.widgets;
 
-public class DefaultRendererFactory implements RendererFactory {
+class DefaultRendererFactory implements RendererFactory {
 	@Override
 	public ButtonRenderer createCheckboxRenderer(Button button) {
 		return new DefaultCheckboxRenderer(button);

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultScaleRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultScaleRenderer.java
@@ -16,7 +16,7 @@ package org.eclipse.swt.widgets;
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 
-public class DefaultScaleRenderer extends ScaleRenderer {
+class DefaultScaleRenderer extends ScaleRenderer {
 
 	private static final int PREFERRED_WIDTH = 170;
 	private static final int PREFERRED_HEIGHT = 42;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultSliderRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultSliderRenderer.java
@@ -15,7 +15,7 @@ package org.eclipse.swt.widgets;
 
 import org.eclipse.swt.graphics.*;
 
-public class DefaultSliderRenderer extends SliderRenderer {
+class DefaultSliderRenderer extends SliderRenderer {
 	private static final int PREFERRED_WIDTH = 170;
 	private static final int PREFERRED_HEIGHT = 18;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultToolBarRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultToolBarRenderer.java
@@ -24,7 +24,7 @@ import org.eclipse.swt.widgets.ToolBarLayout.*;
 /**
  * Default renderer for the ToolBar.
  */
-public class DefaultToolBarRenderer extends ToolBarRenderer {
+class DefaultToolBarRenderer extends ToolBarRenderer {
 
 	public static final Color COLOR_SEPARATOR = new Color(Display.getDefault(), 160, 160, 160);
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultToolBarRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/DefaultToolBarRenderer.java
@@ -11,7 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swt.widgets.toolbar;
+package org.eclipse.swt.widgets;
 
 import java.util.*;
 import java.util.List;
@@ -19,7 +19,7 @@ import java.util.List;
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.widgets.*;
-import org.eclipse.swt.widgets.toolbar.ToolBarLayout.*;
+import org.eclipse.swt.widgets.ToolBarLayout.*;
 
 /**
  * Default renderer for the ToolBar.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolBar.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolBar.java
@@ -18,7 +18,6 @@ import java.util.List;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
-import org.eclipse.swt.widgets.toolbar.*;
 
 /**
  * Instances of this class support the layout of selectable tool bar items.

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolBarLayout.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolBarLayout.java
@@ -11,9 +11,10 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swt.widgets.toolbar;
+package org.eclipse.swt.widgets;
 
 import java.util.*;
+import java.util.List;
 
 import org.eclipse.swt.graphics.*;
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolBarLayoutGenerator.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolBarLayoutGenerator.java
@@ -19,7 +19,7 @@ import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.widgets.ToolBarLayout.*;
 
-public class ToolBarLayoutGenerator {
+class ToolBarLayoutGenerator {
 	private final List<ItemRecord> itemRecords;
 	private final Point availableSize;
 	private final boolean horizontal;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolBarLayoutGenerator.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolBarLayoutGenerator.java
@@ -11,13 +11,13 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swt.widgets.toolbar;
+package org.eclipse.swt.widgets;
 
 import java.util.*;
-
+import java.util.List;
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
-import org.eclipse.swt.widgets.toolbar.ToolBarLayout.*;
+import org.eclipse.swt.widgets.ToolBarLayout.*;
 
 public class ToolBarLayoutGenerator {
 	private final List<ItemRecord> itemRecords;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolItem.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolItem.java
@@ -16,7 +16,6 @@ package org.eclipse.swt.widgets;
 import org.eclipse.swt.*;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.*;
-import org.eclipse.swt.widgets.toolbar.*;
 
 /**
  * Instances of this class represent a selectable user interface object that

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolItemButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolItemButtonRenderer.java
@@ -11,7 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swt.widgets.toolbar;
+package org.eclipse.swt.widgets;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolItemButtonRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolItemButtonRenderer.java
@@ -18,7 +18,7 @@ import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.widgets.*;
 import org.eclipse.swt.widgets.ToolItem.*;
 
-public class ToolItemButtonRenderer implements ToolItemRenderer {
+class ToolItemButtonRenderer implements ToolItemRenderer {
 	private static final int DRAW_FLAGS = SWT.DRAW_MNEMONIC;
 
 	/*

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolItemDropDownRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolItemDropDownRenderer.java
@@ -17,7 +17,7 @@ import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.widgets.ToolItem.*;
 
-public class ToolItemDropDownRenderer implements ToolItemRenderer {
+class ToolItemDropDownRenderer implements ToolItemRenderer {
 	private static final int ARROW_PADDING = 4;
 	private static final int ARROW_WIDTH = 7;
 	private static final int ARROW_HEIGHT = 4;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolItemDropDownRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolItemDropDownRenderer.java
@@ -11,11 +11,10 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swt.widgets.toolbar;
+package org.eclipse.swt.widgets;
 
 import org.eclipse.swt.*;
 import org.eclipse.swt.graphics.*;
-import org.eclipse.swt.widgets.*;
 import org.eclipse.swt.widgets.ToolItem.*;
 
 public class ToolItemDropDownRenderer implements ToolItemRenderer {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolItemSeparatorRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolItemSeparatorRenderer.java
@@ -11,10 +11,9 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swt.widgets.toolbar;
+package org.eclipse.swt.widgets;
 
 import org.eclipse.swt.graphics.*;
-import org.eclipse.swt.widgets.*;
 import org.eclipse.swt.widgets.ToolItem.*;
 
 public class ToolItemSeparatorRenderer implements ToolItemRenderer {

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolItemSeparatorRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/ToolItemSeparatorRenderer.java
@@ -16,7 +16,7 @@ package org.eclipse.swt.widgets;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.widgets.ToolItem.*;
 
-public class ToolItemSeparatorRenderer implements ToolItemRenderer {
+class ToolItemSeparatorRenderer implements ToolItemRenderer {
 	public static final Color COLOR_SEPARATOR = new Color(Display.getDefault(), 160, 160, 160);
 
 	private static final int EMPTY_WIDTH = 7;


### PR DESCRIPTION
- Reduce visibility of the renderers and the factory
- Move all classes in the package o.e.swt.widget.toolbar to the parent
package
- Remove the toolbar package