### PR TITLE
Update parent POM to 4.36 stream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,12 +18,13 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.35.0-SNAPSHOT</version>
+    <version>4.36.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 
   <groupId>eclipse.platform.swt</groupId>
   <artifactId>eclipse.platform.swt</artifactId>
+  <version>4.35.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>


### PR DESCRIPTION
Due to Eclipse Foundation infrastructure issues, the 4.35 parent POM is not available in the Nexus repository anymore. This updates to the 4.36 parent POM which is available.