### PR TITLE
Introduce LinkParser which splits the text of a Link control into its parts

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LinkParser.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/LinkParser.java
@@ -1,0 +1,193 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Syntevo GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Thomas Singer (Syntevo) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.SWT;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Parses link elements.
+ */
+public class LinkParser {
+
+	public static List<Part> parse(String text) {
+		final LinkParser parser = new LinkParser(text);
+		parser.parse();
+		return parser.parts;
+	}
+
+	private final List<Part> parts = new ArrayList<>();
+	private final String text;
+
+	private int next;
+	private int index;
+
+	private LinkParser(String text) {
+		this.text = text;
+
+		next = next();
+	}
+
+	private void parse() {
+		if (next < 0) {
+			return;
+		}
+
+		final StringBuilder buffer = new StringBuilder();
+		while (next >= 0) {
+			if (isConsume('<')) {
+				handleNonEmptyText(buffer);
+				final String target = getTarget();
+				if (target == null) {
+					continue;
+				}
+
+				while (true) {
+					if (next < 0) {
+						return;
+					}
+					if (isConsume('<')) {
+						if (isConsume('/')
+								&& isConsumeIgnoreCase('a')
+								&& isConsume('>')) {
+							parts.add(new Part(buffer.toString(), target));
+						} else {
+							skipAllUntilTagClose();
+						}
+
+						buffer.setLength(0);
+						break;
+					}
+					buffer.append((char) next);
+					consume();
+				}
+			} else {
+				buffer.append((char) next);
+				consume();
+			}
+		}
+		handleNonEmptyText(buffer);
+	}
+
+	private void handleNonEmptyText(StringBuilder buffer) {
+		if (buffer.length() > 0) {
+			parts.add(new Part(buffer.toString(), null));
+			buffer.setLength(0);
+		}
+	}
+
+	private String getTarget() {
+		if (!isConsumeIgnoreCase('a')) {
+			skipAllUntilTagClose();
+			return null;
+		}
+
+		if (isConsume('>')) {
+			return "";
+		}
+
+		if (!isConsumeWhitespace()) {
+			skipAllUntilTagClose();
+			return null;
+		}
+
+		while (isConsumeWhitespace()) {
+			if (next < 0) {
+				return null;
+			}
+		}
+
+		if (!isConsumeIgnoreCase('h')
+				|| !isConsumeIgnoreCase('r')
+				|| !isConsumeIgnoreCase('e')
+				|| !isConsumeIgnoreCase('f')
+				|| !isConsume('=')
+				|| !isConsume('"')) {
+			skipAllUntilTagClose();
+			return null;
+		}
+
+		final StringBuilder target = new StringBuilder();
+		while (!isConsume('"')) {
+			if (next < 0) {
+				return null;
+			}
+			target.append((char) next);
+			consume();
+		}
+
+		if (!skipAllUntilTagClose()) {
+			return null;
+		}
+
+		return target.toString();
+	}
+
+	private boolean skipAllUntilTagClose() {
+		while (!isConsume('>')) {
+			if (next < 0) {
+				return false;
+			}
+			consume();
+		}
+		return true;
+	}
+
+	private boolean isConsume(char expected) {
+		if (next != expected) {
+			return false;
+		}
+		consume();
+		return true;
+	}
+
+	private boolean isConsumeIgnoreCase(char expected) {
+		if (Character.toLowerCase(next) != expected) {
+			return false;
+		}
+		consume();
+		return true;
+	}
+
+	private boolean isConsumeWhitespace() {
+		if (next < 0 || !Character.isWhitespace(next)) {
+			return false;
+		}
+		consume();
+		return true;
+	}
+
+	private void consume() {
+		next = next();
+	}
+
+	private int next() {
+		if (index >= text.length()) {
+			return -1;
+		}
+
+		final char c = text.charAt(index);
+		index++;
+		return c;
+	}
+
+	public record Part(String text, String linkData) {
+		public Part {
+			if (text == null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
+		}
+	}
+}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/TestLinkParser.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/TestLinkParser.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Syntevo GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Thomas Singer (Syntevo) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swt.tests.junit;
+
+import org.eclipse.swt.widgets.LinkParser;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class TestLinkParser {
+	@Test
+	public void testNormal() {
+		testLink(List.of(), "");
+
+		testLink(List.of(new LinkParser.Part("hello", null)), "hello");
+
+		testLink(List.of(new LinkParser.Part("", "")), "<a></a>");
+		testLink(List.of(new LinkParser.Part("", "")), "<A></A>");
+		testLink(List.of(new LinkParser.Part("a", "")), "<a>a</a>");
+		testLink(List.of(new LinkParser.Part("a", "")), "<A>a</A>");
+		testLink(List.of(new LinkParser.Part("a", "")), "<a href=\"\">a</a>");
+		testLink(List.of(new LinkParser.Part("a", "")), "<A HREF=\"\">a</a>");
+		testLink(List.of(new LinkParser.Part("a", "target")), "<a href=\"target\">a</a>");
+		testLink(List.of(new LinkParser.Part("a", "target")), "<A hReF=\"target\">a</a>");
+
+		testLink(List.of(new LinkParser.Part("hello", null),
+				new LinkParser.Part("", ""),
+				new LinkParser.Part("world", null)), "hello<a></a>world");
+		testLink(List.of(new LinkParser.Part(" ", null),
+				new LinkParser.Part("a", ""),
+				new LinkParser.Part("\n", null)), " <a>a</a>\n");
+		testLink(List.of(new LinkParser.Part("s", null),
+				new LinkParser.Part("u", ""),
+				new LinkParser.Part("n", null)), "s<a href=\"\">u</a>n");
+	}
+
+	@Test
+	public void testEdgeCases() {
+		testLink(List.of(), "<a>a</ab>");
+		testLink(List.of(new LinkParser.Part("b", null),
+				new LinkParser.Part("c", null)), "b<a>a</ab>c");
+		testLink(List.of(), "<a>a</b>");
+		testLink(List.of(new LinkParser.Part("b", null)), "b<a></a");
+		testLink(List.of(new LinkParser.Part("b", null)), "b<a></");
+		testLink(List.of(new LinkParser.Part("b", null)), "b<a><");
+		testLink(List.of(new LinkParser.Part("b", null)), "b<a>");
+		testLink(List.of(new LinkParser.Part("b", null)), "b<a");
+		testLink(List.of(new LinkParser.Part("b", null)), "b<");
+		testLink(List.of(new LinkParser.Part("b", null),
+				new LinkParser.Part("a", null),
+				new LinkParser.Part("c", null)), "b<ahref=\"\">a</a>c");
+		testLink(List.of(new LinkParser.Part("b", null)), "b<a href=\">c");
+		testLink(List.of(new LinkParser.Part("b", null),
+				new LinkParser.Part("c", null)), "b<a href=>c");
+		testLink(List.of(new LinkParser.Part("b", null),
+				new LinkParser.Part("c", null)), "b<a href>c");
+		testLink(List.of(new LinkParser.Part("b", null),
+				new LinkParser.Part("c", null)), "b<a hre>c");
+		testLink(List.of(new LinkParser.Part("b", null),
+				new LinkParser.Part("c", null)), "b<a hr>c");
+		testLink(List.of(new LinkParser.Part("b", null),
+				new LinkParser.Part("c", null)), "b<a h>c");
+		testLink(List.of(new LinkParser.Part("b", null),
+				new LinkParser.Part("c", null)), "b<a >c");
+		testLink(List.of(new LinkParser.Part("b", null)), "b<a c");
+	}
+
+	private void testLink(List<LinkParser.Part> expected, String text) {
+		final List<LinkParser.Part> actual = LinkParser.parse(text);
+		Assert.assertEquals(expected, actual);
+	}
+}

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Link.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Link.java
@@ -183,39 +183,4 @@ public void test_setLinkForegroundLorg_eclipse_swt_graphics_Color() {
 	link.setLinkForeground(null);
 	assertNotEquals(color, link.getForeground());
 }
-
-// DefaultLinkRenderer is not public
-//@Test
-//public void testparseLinkText() {
-//	String linkText = "Start  <a  href=\"targetLink\">click here</a>\n\n\n\ntest <a href=\"targetLink1\">targetline1\n\ntargetline2</a> same as line anchor\n\nLast line";
-//	String expDisplayText = "Start  click here\n"
-//			+ "\n"
-//			+ "\n"
-//			+ "\n"
-//			+ "test targetline1\n"
-//			+ "\n"
-//			+ "targetline2 same as line anchor\n"
-//			+ "\n"
-//			+ "Last line";
-//	LinkRenderer defLinkRendrer = new DefaultLinkRenderer(null);
-//	defLinkRendrer.parseLinkText(linkText);
-//	List<List<TextSegment>> parsedText = defLinkRendrer.getParsedSegments();
-//	String actual = defLinkRendrer.getLinkDisplayText();
-//	assertEquals("Incorrect display message: ", expDisplayText, actual);
-//
-//	int numberOfLines = expDisplayText.split("\n", -1).length;
-//	assertEquals("Incorrect number of segments: ", numberOfLines, parsedText.size());
-//
-//	assertTrue("First line second segment must be a link: ", parsedText.get(0).get(1).isLink());
-//	assertEquals("First line incorrect link display text: ", "click here", parsedText.get(0).get(1).text);
-//	assertEquals("First line incorrect link data: ", "targetLink", parsedText.get(0).get(1).linkData);
-//
-//	assertTrue("Fifth line second segment must be a link: ", parsedText.get(4).get(1).isLink());
-//	assertEquals("Fifth line incorrect link display text: ", "targetline1", parsedText.get(4).get(1).text);
-//	assertEquals("Fifth line incorrect link data: ", "targetLink1", parsedText.get(4).get(1).linkData);
-//
-//	assertTrue("Seventh line first segment must be a link: ", parsedText.get(6).get(0).isLink());
-//	assertEquals("Seventh line incorrect link display text: ", "targetline2", parsedText.get(6).get(0).text);
-//	assertEquals("Seventh line incorrect link data: ", "targetLink1", parsedText.get(6).get(0).linkData);
-//}
 }


### PR DESCRIPTION
This should fix the broken ControlExample "Link" tab.

Please verify especially the `TestLinkParser` whether it is correctly invoked.