### PR TITLE
Table.dispose: don't dispose columns and items explicitly

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Table.java
@@ -2968,39 +2968,6 @@ public class Table extends CustomComposite {
 		return renderer;
 	}
 
-	@Override
-	public void dispose() {
-		/*
-		 * Note: It is valid to attempt to dispose a widget more than once. If this
-		 * happens, fail silently.
-		 */
-
-		if (isDisposed()) return;
-		if (!isValidThread()) error(SWT.ERROR_THREAD_INVALID_ACCESS);
-
-		var columnsSet = new HashSet<TableColumn>();
-		var itemsSet = new HashSet<TableItem>();
-
-		columnsSet.addAll(columnsList);
-		itemsSet.addAll(itemsList);
-		itemsSet.addAll(virtualItemsList.values());
-
-		itemsList.clear();
-		columnsList.clear();
-		virtualItemsList.clear();
-		virtualItemCount = 0;
-
-		for (var c : columnsSet) {
-			c.dispose();
-		}
-
-		for (var i : itemsSet) {
-			i.dispose();
-		}
-
-		super.dispose();
-	}
-
 	static void logNotImplemented() {
 		if (LOG_NOT_IMPLEMENTED) {
 			System.out.println("WARN: Not implemented yet: " + new Throwable().getStackTrace()[1]);

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Table.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_widgets_Table.java
@@ -1916,4 +1916,35 @@ public void test_setTopIndex() {
 	shell.setVisible(false);
 	assertEquals(5, table.getTopIndex());
 }
+
+@Test
+public void testDisposeStillValidColumn() {
+	assertEquals(0, table.getColumnCount());
+	assertEquals(0, table.getItemCount());
+
+	final TableColumn column = new TableColumn(table, SWT.LEFT);
+	column.setText("Column");
+	column.setWidth(40);
+
+	new TableItem(table, SWT.LEFT)
+			.setText("item");
+
+	boolean[] disposeInvoked = new boolean[1];
+	table.addListener(SWT.Dispose, event -> {
+		// the columns and items must be disposed *after* the table sent the dispose event
+		final TableColumn column0 = table.getColumn(0);
+		assertEquals("Column", column0.getText());
+
+		final TableItem item0 = table.getItem(0);
+		assertEquals("item", item0.getText());
+
+		disposeInvoked[0] = true;
+	});
+
+	table.setSize(50, 50);
+	shell.open();
+	// will dispose the table:
+	setWidget(null);
+	assertTrue(disposeInvoked[0]);
+}
 }


### PR DESCRIPTION
they will be disposed automatically in Table.releaseChildren