### PR TITLE
Revert Label word wrap: The current TextLayout implementation does not support this sufficiently

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/BasicLabelRenderer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/BasicLabelRenderer.java
@@ -80,7 +80,7 @@ class BasicLabelRenderer extends LabelRenderer {
 		TextLayout layout=null;
 		try {
 		if (!text.isEmpty()) {
-			if (wrap) {
+			if (wrap && false /* word wrap not possible textlayout insufficient */ ) {
 				layout = new TextLayout(label.getDisplay());
 				layout.setFont(gc.getFont());
 				layout.setText(text);
@@ -181,6 +181,8 @@ class BasicLabelRenderer extends LabelRenderer {
 		}
 
 		// draw the text
+		// TextLayout is currently insufficient for label drawing.
+		layout = null;
 		if (wrap && layout != null) {
 			int lineY = topMargin;
 			if (textHeight < imageHeight) {
@@ -189,7 +191,7 @@ class BasicLabelRenderer extends LabelRenderer {
 			gc.setForeground(label.isEnabled() ? label.getForeground() : getColor(COLOR_DISABLED));
 			gc.setAntialias(SWT.ON);
 			gc.setTextAntialias(SWT.ON);
-			layout.draw(gc, x, lineY);
+			layout.draw(gc, x, lineY, -1, -1, null, null, DRAW_FLAGS);
 		} else if (lines != null) {
 			// we draw the label at the top.
 			int lineY = topMargin;

--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/widgets/Label.java
@@ -327,14 +327,6 @@ public class Label extends CustomControl {
 		return renderer.getTopMargin();
 	}
 
-	/**
-	 * Returns true if the label wraps text (SWT.WRAP), false otherwise.
-	 * @return true if wrap is enabled
-	 */
-	public boolean getWrap() {
-		return wrap;
-	}
-
 	private void initAccessible() {
 		Accessible accessible = getAccessible();
 		accessible.addAccessibleListener(new AccessibleAdapter() {


### PR DESCRIPTION
The TextLayout does not support word wrapping for the label sufficiently.

- insufficient font support
- no SWT.DRAW_MNEMONIC handling