### PR TITLE
[linux] Fix Linux Skja Font size

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/common/org/eclipse/swt/graphics/SkijaGC.java
@@ -913,6 +913,10 @@ public class SkijaGC extends GCHandle {
 		if (SWT.getPlatform().equals("win32")) {
 			fontSize *= skijaFont.getSize() / Display.getDefault().getSystemFont().getFontData()[0].getHeight();
 		}
+		if (SWT.getPlatform().equals("gtk")) {
+			// SWT's font size is in points, 1pt = 1/72 inch, adjust skija font size to this
+			fontSize = (fontSize * Display.getDefault().getDPI().y) / 72;
+		}
 		skijaFont.setSize(fontSize);
 		skijaFont.setEdging(FontEdging.SUBPIXEL_ANTI_ALIAS);
 		skijaFont.setSubpixel(true);


### PR DESCRIPTION
SWT font size is in points while skjaf expects font size in pixels. To get the right font size pts have to be translated to pixels using the fact that 1pt = 1/72inch. Therefore also the displays DPI are needed.